### PR TITLE
Feature/17 search by newsletter issue

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -68,6 +68,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 - {url-issues}13[#13] - Core: SummaryPDF to show concatenated short fields if main fields methods/population/results are null.
   Also search by population place in quick search field `method`.
 - {url-issues}17[#17] - Core: Let user filter by newsletter. Also enable (and fix) searching by newsletter topic and headline.
+  Also fix auto-saving behavior of the non-tabbed fields in the Search Page.
   
 
 .Deprecated

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -67,7 +67,8 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Changed
 - {url-issues}13[#13] - Core: SummaryPDF to show concatenated short fields if main fields methods/population/results are null.
   Also search by population place in quick search field `method`.
-- {url-issues}17[#17] - Core: Let user filter by newsletter. Also enable searching by newsletter topic and headline.
+- {url-issues}17[#17] - Core: Let user filter by newsletter. Also enable (and fix) searching by newsletter topic and headline.
+  
 
 .Deprecated
 

--- a/implementation/scipamato/scipamato-core-entity/src/main/java/ch/difty/scipamato/core/entity/search/SearchCondition.java
+++ b/implementation/scipamato/scipamato-core-entity/src/main/java/ch/difty/scipamato/core/entity/search/SearchCondition.java
@@ -48,6 +48,7 @@ public class SearchCondition extends ScipamatoFilter implements CodeBoxAware, Ne
     private static final String JOIN_DELIMITER = " AND ";
 
     private Long    searchConditionId;
+    // not identifying and therefore not used for equals or hashcode
     private String  newsletterHeadline;
     private Integer newsletterTopicId;
     private String  newsletterIssue;
@@ -585,9 +586,6 @@ public class SearchCondition extends ScipamatoFilter implements CodeBoxAware, Ne
         final int prime = 31;
         int result = 1;
         result = prime * result + (searchConditionId == null ? 0 : searchConditionId.hashCode());
-        result = prime * result + (newsletterTopicId == null ? 0 : newsletterTopicId.hashCode());
-        result = prime * result + (newsletterHeadline == null ? 0 : newsletterHeadline.hashCode());
-        result = prime * result + (newsletterIssue == null ? 0 : newsletterIssue.hashCode());
         result = prime * result + stringSearchTerms.hashCode();
         result = prime * result + integerSearchTerms.hashCode();
         result = prime * result + booleanSearchTerms.hashCode();
@@ -609,21 +607,6 @@ public class SearchCondition extends ScipamatoFilter implements CodeBoxAware, Ne
             if (other.searchConditionId != null)
                 return false;
         } else if (!searchConditionId.equals(other.searchConditionId))
-            return false;
-        if (newsletterTopicId == null) {
-            if (other.newsletterTopicId != null)
-                return false;
-        } else if (!newsletterTopicId.equals(other.newsletterTopicId))
-            return false;
-        if (newsletterHeadline == null) {
-            if (other.newsletterHeadline != null)
-                return false;
-        } else if (!newsletterHeadline.equals(other.newsletterHeadline))
-            return false;
-        if (newsletterIssue == null) {
-            if (other.newsletterIssue != null)
-                return false;
-        } else if (!newsletterIssue.equals(other.newsletterIssue))
             return false;
         if (!booleanSearchTerms.equals(other.booleanSearchTerms))
             return false;

--- a/implementation/scipamato/scipamato-core-entity/src/test/java/ch/difty/scipamato/core/entity/search/SearchConditionTest.java
+++ b/implementation/scipamato/scipamato-core-entity/src/test/java/ch/difty/scipamato/core/entity/search/SearchConditionTest.java
@@ -956,57 +956,57 @@ public class SearchConditionTest {
     }
 
     @Test
-    public void equalsAndHash12_withDifferentNewsletterTopics() {
+    public void equalsAndHash12_withDifferentNewsletterTopics_notDifferent() {
         SearchCondition f1 = new SearchCondition();
         f1.setNewsletterTopic(new NewsletterTopic(1, "foo"));
         SearchCondition f2 = new SearchCondition();
         f2.setNewsletterTopic(new NewsletterTopic(2, "foo"));
-        assertInequality(f1, f2);
+        assertEquality(f1, f2);
     }
 
     @Test
-    public void equalsAndHash13_withDifferentNewsletterHeadlines() {
+    public void equalsAndHash13_withDifferentNewsletterHeadlines_notDifferent() {
         SearchCondition f1 = new SearchCondition();
         f1.setNewsletterHeadline("foo");
         SearchCondition f2 = new SearchCondition();
         f2.setNewsletterHeadline("bar");
-        assertInequality(f1, f2);
+        assertEquality(f1, f2);
     }
 
     @Test
-    public void equalsAndHash14_withDifferentNewsletterIssue() {
+    public void equalsAndHash14_withDifferentNewsletterIssue_notDifferent() {
         SearchCondition f1 = new SearchCondition();
         f1.setNewsletterIssue("foo");
         SearchCondition f2 = new SearchCondition();
         f2.setNewsletterIssue("bar");
-        assertInequality(f1, f2);
+        assertEquality(f1, f2);
     }
 
     @Test
-    public void equalsAndHash15_withDifferentNewsletterTopics_firstNull() {
+    public void equalsAndHash15_withDifferentNewsletterTopics_firstNull_notDifferent() {
         SearchCondition f1 = new SearchCondition();
         f1.setNewsletterTopic(null);
         SearchCondition f2 = new SearchCondition();
         f2.setNewsletterTopic(new NewsletterTopic(2, "foo"));
-        assertInequality(f1, f2);
+        assertEquality(f1, f2);
     }
 
     @Test
-    public void equalsAndHash16_withDifferentNewsletterHeadlines_firstNull() {
+    public void equalsAndHash16_withDifferentNewsletterHeadlines_firstNull_notDifferent() {
         SearchCondition f1 = new SearchCondition();
         f1.setNewsletterHeadline(null);
         SearchCondition f2 = new SearchCondition();
         f2.setNewsletterHeadline("bar");
-        assertInequality(f1, f2);
+        assertEquality(f1, f2);
     }
 
     @Test
-    public void equalsAndHash17_withDifferentNewsletterIssue_firstNull() {
+    public void equalsAndHash17_withDifferentNewsletterIssue_firstNull_notDifferent() {
         SearchCondition f1 = new SearchCondition();
         f1.setNewsletterIssue(null);
         SearchCondition f2 = new SearchCondition();
         f2.setNewsletterIssue("bar");
-        assertInequality(f1, f2);
+        assertEquality(f1, f2);
     }
 
     @Test

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel.java
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel.java
@@ -55,7 +55,7 @@ import ch.difty.scipamato.core.web.paper.jasper.JasperPaperDataSource;
 import ch.difty.scipamato.core.web.paper.jasper.summary.PaperSummaryDataSource;
 import ch.difty.scipamato.core.web.paper.jasper.summaryshort.PaperSummaryShortDataSource;
 
-@SuppressWarnings("SameParameterValue")
+@SuppressWarnings({ "SameParameterValue", "WicketForgeJavaIdInspection" })
 public abstract class PaperPanel<T extends CodeBoxAware & NewsletterAware> extends BasePanel<T> {
 
     private static final long serialVersionUID = 1L;

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/entry/PaperEntryPage.java
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/entry/PaperEntryPage.java
@@ -239,7 +239,7 @@ public class PaperEntryPage extends SelfUpdatingPage<Paper> {
         try {
             if (mode == Mode.EDIT) {
                 final boolean newPaper = getNullSafeId() == 0;
-                Paper persisted = service.saveOrUpdate(paper);
+                final Paper persisted = service.saveOrUpdate(paper);
                 if (persisted != null) {
                     setModelObject(persisted);
                     resetFeedbackMessages();

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/search/PaperSearchCriteriaPage.java
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/search/PaperSearchCriteriaPage.java
@@ -64,8 +64,9 @@ public class PaperSearchCriteriaPage extends BasePage<SearchCondition> {
                 Long searchOrderId = getSearchOrderId();
                 if (searchOrderId != null) {
                     try {
-                        searchOrderService.saveOrUpdateSearchCondition(getModelObject(), searchOrderId,
-                            getLanguageCode());
+                        final SearchCondition sc = searchOrderService.saveOrUpdateSearchCondition(getModelObject(),
+                            searchOrderId, getLanguageCode());
+                        setModelObject(sc);
                     } catch (Exception ex) {
                         error(new StringResourceModel("save.error.hint", this, null)
                             .setParameters(getNullSafeId(), ex.getMessage())

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/search/PaperSearchCriteriaPage.java
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/search/PaperSearchCriteriaPage.java
@@ -12,6 +12,7 @@ import ch.difty.scipamato.core.entity.search.SearchOrder;
 import ch.difty.scipamato.core.persistence.SearchOrderService;
 import ch.difty.scipamato.core.web.CorePageParameters;
 import ch.difty.scipamato.core.web.common.BasePage;
+import ch.difty.scipamato.core.web.common.SelfUpdateBroadcastingBehavior;
 import ch.difty.scipamato.core.web.paper.PageFactory;
 import ch.difty.scipamato.core.web.paper.common.SearchablePaperPanel;
 
@@ -51,7 +52,11 @@ public class PaperSearchCriteriaPage extends BasePage<SearchCondition> {
     protected void onInitialize() {
         super.onInitialize();
 
-        queue(makeSearchablePanel("contentPanel"));
+        final SearchablePaperPanel panel = makeSearchablePanel("contentPanel");
+        queue(panel);
+        panel
+            .getForm()
+            .add(new SelfUpdateBroadcastingBehavior(getPage()));
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/search/SearchOrderSelectorPanel.java
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/search/SearchOrderSelectorPanel.java
@@ -193,7 +193,6 @@ public class SearchOrderSelectorPanel extends BasePanel<SearchOrder> {
         if (so != null) {
             form.setDefaultModelObject(so);
         }
-        modelChanged();
     }
 
     private boolean isModelSelected() {

--- a/implementation/scipamato/scipamato-core-web/src/test/java/ch/difty/scipamato/core/web/paper/search/PaperSearchCriteriaPageTest.java
+++ b/implementation/scipamato/scipamato-core-web/src/test/java/ch/difty/scipamato/core/web/paper/search/PaperSearchCriteriaPageTest.java
@@ -81,8 +81,7 @@ public class PaperSearchCriteriaPageTest extends BasePageTest<PaperSearchCriteri
         getTester().assertRenderedPage(getPageClass());
         getTester().assertNoErrorMessage();
 
-        verify(searchOrderServiceMock, times(2)).saveOrUpdateSearchCondition(searchConditionMock, SEARCH_ORDER_ID,
-            "en_us");
+        verify(searchOrderServiceMock).saveOrUpdateSearchCondition(searchConditionMock, SEARCH_ORDER_ID, "en_us");
         verify(searchOrderServiceMock, never()).findPageByFilter(isA(SearchOrderFilter.class),
             isA(PaginationContext.class));
     }
@@ -98,8 +97,7 @@ public class PaperSearchCriteriaPageTest extends BasePageTest<PaperSearchCriteri
         getTester().assertRenderedPage(PaperSearchPage.class);
         getTester().assertNoErrorMessage();
 
-        verify(searchOrderServiceMock, times(3)).saveOrUpdateSearchCondition(searchConditionMock, SEARCH_ORDER_ID,
-            "en_us");
+        verify(searchOrderServiceMock).saveOrUpdateSearchCondition(searchConditionMock, SEARCH_ORDER_ID, "en_us");
         verify(searchOrderServiceMock).findPageByFilter(isA(SearchOrderFilter.class), isA(PaginationContext.class));
     }
 


### PR DESCRIPTION
Gathers a few fixes that came out of the users tests with feature 17.

* The management of identity (equals/hashcode) of the SearchCondition had to be adjusted as initially we had hardly any state in the class (except for the database id). All the rest was in nested objects. With newsletter specific state (issue, headline, topic) sneaking into the class, the logic to reuse persisted searchConditions if they were equivalent was wrongly creating new records where reuse would have been possible. This duplicated some conditions unnecessarily and wrongly. Also, the reused conditions were not enriched upon saving and therefore 'forgot' the newsletter specific fields. Evenmore, the page was not resetting the model with the updated record.
* The search edit page was not auto-saving the fields that are not in a nested tab (since the migration of the tab a few weeks ago).