### PR TITLE
Provide better feedback about the underlying cause if the PubMed API …

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -71,6 +71,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Fixed
 - {url-issues}44[#44] - Core & Public: Fix typo in Code '4H' (en): cardovascular -> cardiovascular
 - {url-issues}46[#46] - Sync: Fix exception (NPE) when synchronizing NewStudyTopics from Core to Public
+- {url-issues}48[#48] - Core: Provide better feedback about the underlying cause if the PubMed API is unable to retrieve an article
 
 .Security
 

--- a/implementation/scipamato/scipamato-core-persistence-jooq/src/test/java/ch/difty/scipamato/core/persistence/TestApplication.java
+++ b/implementation/scipamato/scipamato-core-persistence-jooq/src/test/java/ch/difty/scipamato/core/persistence/TestApplication.java
@@ -2,7 +2,6 @@ package ch.difty.scipamato.core.persistence;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -14,6 +13,7 @@ import ch.difty.scipamato.common.DateTimeService;
 import ch.difty.scipamato.common.FrozenDateTimeService;
 import ch.difty.scipamato.common.config.ApplicationProperties;
 import ch.difty.scipamato.core.pubmed.PubmedArticleFacade;
+import ch.difty.scipamato.core.pubmed.PubmedArticleResult;
 import ch.difty.scipamato.core.pubmed.PubmedArticleService;
 
 @SpringBootApplication
@@ -72,14 +72,13 @@ public class TestApplication {
         return new PubmedArticleService() {
 
             @Override
-            public Optional<PubmedArticleFacade> getPubmedArticleWithPmid(int pmId) {
-                return Optional.empty();
+            public PubmedArticleResult getPubmedArticleWithPmid(int pmId) {
+                return new PubmedArticleResult(null, null, null);
             }
 
             @Override
-            public Optional<PubmedArticleFacade> getPubmedArticleWithPmidAndApiKey(final int pmId,
-                final String apiKey) {
-                return Optional.empty();
+            public PubmedArticleResult getPubmedArticleWithPmidAndApiKey(final int pmId, final String apiKey) {
+                return new PubmedArticleResult(null, null, null);
             }
 
             @Override

--- a/implementation/scipamato/scipamato-core-pubmed-api/src/main/java/ch/difty/scipamato/core/pubmed/PubmedArticleResult.java
+++ b/implementation/scipamato/scipamato-core-pubmed-api/src/main/java/ch/difty/scipamato/core/pubmed/PubmedArticleResult.java
@@ -1,0 +1,80 @@
+package ch.difty.scipamato.core.pubmed;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Data Class providing the {@link PubmedArticleFacade} or an error specific message
+ * providing information about the problem that prevented the retrieval of the article.
+ */
+@Getter
+public class PubmedArticleResult {
+
+    private static final Pattern ERROR_PATTERN  = Pattern.compile(".+\\{\"error\":\"([^\"]*)\",.+}", Pattern.DOTALL);
+    private static final Pattern REASON_PATTERN = Pattern.compile(".+Reason: <strong>([^<]+)</strong>+.+",
+        Pattern.DOTALL);
+
+    private final PubmedArticleFacade pubmedArticleFacade;
+    private final String              errorMessage;
+
+    public PubmedArticleResult(final PubmedArticleFacade pubmedArticleFacade, final HttpStatus httpStatus,
+        final String rawMessage) {
+        this.pubmedArticleFacade = pubmedArticleFacade;
+        this.errorMessage = evaluateMessageFrom(httpStatus, rawMessage);
+    }
+
+    private String evaluateMessageFrom(final HttpStatus httpStatus, final String rawMessage) {
+        if (pubmedArticleFacade != null)
+            return null;
+        if (httpStatus == null)
+            return rawMessage;
+        switch (httpStatus) {
+        case OK:
+            return rawMessage;
+        case BAD_REQUEST:
+            return wrap(httpStatus, extractErrorFrom(rawMessage));
+        case BAD_GATEWAY:
+            return wrap(httpStatus, extractReasonFrom(rawMessage));
+        default:
+            return wrap(httpStatus, fullMessage(rawMessage));
+        }
+    }
+
+    private String wrap(final HttpStatus status, final String msg) {
+        return "Status " + status.toString() + msg;
+    }
+
+    private String extractErrorFrom(final String rawMessage) {
+        return extractPattern(rawMessage, ERROR_PATTERN);
+    }
+
+    private String extractPattern(final String rawMessage, final Pattern pattern) {
+        if (StringUtils.isNotEmpty(rawMessage)) {
+            final Matcher matcher = pattern.matcher(rawMessage);
+            if (matcher.matches())
+                return prependColumn(matcher.group(1));
+            else
+                return prependColumn(rawMessage);
+        }
+        return "";
+    }
+
+    private String prependColumn(String msg) {
+        return ": " + msg;
+    }
+
+    private String extractReasonFrom(final String rawMessage) {
+        return extractPattern(rawMessage, REASON_PATTERN);
+    }
+
+    private String fullMessage(final String rawMessage) {
+        if (StringUtils.isNotEmpty(rawMessage))
+            return prependColumn(rawMessage);
+        return "";
+    }
+
+}

--- a/implementation/scipamato/scipamato-core-pubmed-api/src/main/java/ch/difty/scipamato/core/pubmed/PubmedArticleService.java
+++ b/implementation/scipamato/scipamato-core-pubmed-api/src/main/java/ch/difty/scipamato/core/pubmed/PubmedArticleService.java
@@ -1,7 +1,6 @@
 package ch.difty.scipamato.core.pubmed;
 
 import java.util.List;
-import java.util.Optional;
 
 import ch.difty.scipamato.common.NullArgumentException;
 
@@ -18,9 +17,9 @@ public interface PubmedArticleService {
      *
      * @param pmId
      *     pubmedId
-     * @return optional of {@link PubmedArticleFacade}
+     * @return {@link PubmedArticleResult} holding the {@link PubmedArticleFacade} and some status information
      */
-    Optional<PubmedArticleFacade> getPubmedArticleWithPmid(int pmId);
+    PubmedArticleResult getPubmedArticleWithPmid(int pmId);
 
     /**
      * Retrieve the pubmed article with the provided pmID directly from PubMed, using
@@ -30,9 +29,9 @@ public interface PubmedArticleService {
      *     pubmedId
      * @param apiKey
      *     the PubmedApi Key - must not be null
-     * @return optional of {@link PubmedArticleFacade}
+     * @return PubmedArticleResult holding the PubmedArticleFacade and some status information
      */
-    Optional<PubmedArticleFacade> getPubmedArticleWithPmidAndApiKey(int pmId, String apiKey);
+    PubmedArticleResult getPubmedArticleWithPmidAndApiKey(int pmId, String apiKey);
 
     /**
      * Extracts pubmed articles and pubmed book articles from a a source string. It

--- a/implementation/scipamato/scipamato-core-pubmed-api/src/test/java/ch/difty/scipamato/core/pubmed/PubmedArticleResultTest.java
+++ b/implementation/scipamato/scipamato-core-pubmed-api/src/test/java/ch/difty/scipamato/core/pubmed/PubmedArticleResultTest.java
@@ -1,0 +1,159 @@
+package ch.difty.scipamato.core.pubmed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PubmedArticleResultTest {
+
+    @Mock
+    private PubmedArticleFacade paf;
+
+    private void assertPar(PubmedArticleResult par, final PubmedArticleFacade paf, final String msg) {
+        assertThat(par.getPubmedArticleFacade()).isEqualTo(paf);
+        assertThat(par.getErrorMessage()).isEqualTo(msg);
+    }
+
+    @Test
+    public void withPubmedArticleFacade_messageIsAlwaysNull() {
+        assertPar(new PubmedArticleResult(paf, null, null), paf, null);
+        assertPar(new PubmedArticleResult(paf, HttpStatus.OK, "foo"), paf, null);
+        assertPar(new PubmedArticleResult(paf, null, "foo"), paf, null);
+        assertPar(new PubmedArticleResult(paf, HttpStatus.BAD_GATEWAY, "foo"), paf, null);
+    }
+
+    @Test
+    public void withNoPubmedArticleFacade_withNullStatus_messageIsRawMessage() {
+        final HttpStatus status = null;
+        assertPar(new PubmedArticleResult(null, status, "foo"), null, "foo");
+        assertPar(new PubmedArticleResult(null, status, null), null, null);
+    }
+
+    @Test
+    public void withNoFacade_withStatus200_messageIsRawMessage() {
+        final HttpStatus status = HttpStatus.OK;
+        assertPar(new PubmedArticleResult(null, status, "foo"), null, "foo");
+        assertPar(new PubmedArticleResult(null, status, null), null, null);
+    }
+
+    @Test
+    public void withNoFacade_withStatus400_withNullMessage_messageIsHttpStatus() {
+        final HttpStatus status = HttpStatus.BAD_REQUEST;
+        final String msg = null;
+        assertPar(new PubmedArticleResult(null, status, msg), null, "Status 400 BAD_REQUEST");
+    }
+
+    @Test
+    public void withNoFacade_withStatus400_witValidMessage_messageIsHttpStatusPlusErrorTag() {
+        final HttpStatus status = HttpStatus.BAD_REQUEST;
+        final String msg = "status 400 reading PubMed#articleWithId(String,String); content:\n"
+                           + "{\"error\":\"API key invalid\",\"api-key\":\"xxx\",\"type\":\"invalid\",\"status\":\"unknown\"}";
+        assertPar(new PubmedArticleResult(null, status, msg), null, "Status 400 BAD_REQUEST: API key invalid");
+    }
+
+    @Test
+    public void withNoFacade_withStatus400_witValidMessage_messageIsHttpStatusPlusRawMessage() {
+        final HttpStatus status = HttpStatus.BAD_REQUEST;
+        final String msg = "status 400 reading PubMed#articleWithId(String,String); content:\n" + "bar";
+        assertPar(new PubmedArticleResult(null, status, msg), null,
+            "Status 400 BAD_REQUEST: status 400 reading PubMed#articleWithId(String,String); content:\nbar");
+    }
+
+    @Test
+    public void withNoFacade_withStatus502_withNullMessage_messageIsHttpStatus() {
+        final HttpStatus status = HttpStatus.BAD_GATEWAY;
+        final String msg = null;
+        assertPar(new PubmedArticleResult(null, status, msg), null, "Status 502 BAD_GATEWAY");
+    }
+
+    @Test
+    public void withNoFacade_withStatus502_witValidMessage_messageIsHttpStatusPlusReason() {
+        final HttpStatus status = HttpStatus.BAD_GATEWAY;
+        final String msg = "status 502 reading PubMed#articleWithId(String,String); content:\n"
+                           + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                           + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n"
+                           + "  \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+                           + "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n" + "<head>\n"
+                           + "<title>Bad Gateway!</title>\n"
+                           + "<link rev=\"made\" href=\"mailto:info@ncbi.nlm.nih.gov\" />\n"
+                           + "<style type=\"text/css\"><!--/*--><![CDATA[/*><!--*/ \n"
+                           + "    body { color: #000000; background-color: #FFFFFF; }\n"
+                           + "    a:link { color: #0000CC; }\n" + "    p, address {margin-left: 3em;}\n"
+                           + "    span {font-size: smaller;}\n" + "/*]]>*/--></style>\n" + "</head>\n" + "\n"
+                           + "<body>\n" + "<h1>Bad Gateway!</h1>\n" + "<p>\n" + "\n" + "\n"
+                           + "    The proxy server received an invalid\n" + "    response from an upstream server.\n"
+                           + "\n" + "  \n" + "    </p>\n" + "<p>\n" + "\n"
+                           + "    The proxy server could not handle the request <em><a href=\"/entrez/eutils/efetch.fcgi\">GET&nbsp;/entrez/eutils/efetch.fcgi</a></em>.<p>\n"
+                           + "Reason: <strong>Error reading from remote server</strong></p>\n" + "  \n" + "    \n"
+                           + "</p>\n" + "<p>\n" + "If you think this is a server error, please contact\n"
+                           + "the <a href=\"mailto:info@ncbi.nlm.nih.gov\">webmaster</a>.\n" + "\n" + "</p>\n" + "\n"
+                           + "\n"
+                           + "<h2>Error 502</h2>                                                                                                                                                                                                                                                    [301/810]\n"
+                           + "<address>\n" + "  <a href=\"/\">eutils.ncbi.nlm.nih.gov</a><br />\n"
+                           + "  <span>Apache</span>\n" + "</address>\n" + "</body>\n" + "</html>\n" + "\n" + "\n"
+                           + "2019-01-24 12:26:40.303 ERROR 25027 --- [XNIO-1 task-47] c.d.s.core.pubmed.PubmedXmlService       : Unexpected error: status 502 reading PubMed#articleWithId(String,String); content:\n"
+                           + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                           + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n"
+                           + "  \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+                           + "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n" + "<head>\n"
+                           + "<title>Bad Gateway!</title>\n"
+                           + "<link rev=\"made\" href=\"mailto:info@ncbi.nlm.nih.gov\" />\n"
+                           + "<style type=\"text/css\"><!--/*--><![CDATA[/*><!--*/ \n"
+                           + "    body { color: #000000; background-color: #FFFFFF; }\n"
+                           + "    a:link { color: #0000CC; }\n" + "    p, address {margin-left: 3em;}\n"
+                           + "    span {font-size: smaller;}\n" + "/*]]>*/--></style>\n" + "</head>\n" + "\n"
+                           + "<body>\n" + "<h1>Bad Gateway!</h1>\n" + "<p>\n" + "\n" + "\n"
+                           + "    The proxy server received an invalid\n" + "    response from an upstream server.\n"
+                           + "\n" + "  \n" + "    </p>\n" + "<p>\n" + "\n"
+                           + "    The proxy server could not handle the request <em><a href=\"/entrez/eutils/efetch.fcgi\">GET&nbsp;/entrez/eutils/efetch.fcgi</a></em>.<p>\n"
+                           + "Reason: <strong>Error reading from remote server</strong></p>\n" + "  \n" + "    \n"
+                           + "</p>\n" + "<p>\n" + "If you think this is a server error, please contact\n"
+                           + "the <a href=\"mailto:info@ncbi.nlm.nih.gov\">webmaster</a>.\n" + "\n" + "</p>\n" + "\n"
+                           + "<h2>Error 502</h2>\n" + "<address>\n"
+                           + "  <a href=\"/\">eutils.ncbi.nlm.nih.gov</a><br />\n" + "  <span>Apache</span>\n"
+                           + "</address>\n" + "</body>\n" + "</html>\n";
+        assertPar(new PubmedArticleResult(null, status, msg), null,
+            "Status 502 BAD_GATEWAY: Error reading from remote server");
+    }
+
+    @Test
+    public void withNoFacade_withStatus502_witValidMessage_messageIsHttpStatusPlusRawMessage() {
+        final HttpStatus status = HttpStatus.BAD_GATEWAY;
+        final String msg = "status 502 reading PubMed#articleWithId(String,String); content:\n"
+                           + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                           + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n"
+                           + "  \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+                           + "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n" + "<head>\n"
+                           + "<title>Bad Gateway!</title>\n"
+                           + "<link rev=\"made\" href=\"mailto:info@ncbi.nlm.nih.gov\" />\n"
+                           + "<style type=\"text/css\"><!--/*--><![CDATA[/*><!--*/ \n"
+                           + "    body { color: #000000; background-color: #FFFFFF; }\n"
+                           + "    a:link { color: #0000CC; }\n" + "    p, address {margin-left: 3em;}\n"
+                           + "    span {font-size: smaller;}\n" + "/*]]>*/--></style>\n" + "</head>\n" + "\n"
+                           + "<body>\n" + "</body>\n" + "</html>\n";
+        assertPar(new PubmedArticleResult(null, status, msg), null,
+            "Status 502 BAD_GATEWAY: status 502 reading PubMed#articleWithId(String,String); content:\n"
+            + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n"
+            + "  \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+            + "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n" + "<head>\n"
+            + "<title>Bad Gateway!</title>\n" + "<link rev=\"made\" href=\"mailto:info@ncbi.nlm.nih.gov\" />\n"
+            + "<style type=\"text/css\"><!--/*--><![CDATA[/*><!--*/ \n"
+            + "    body { color: #000000; background-color: #FFFFFF; }\n" + "    a:link { color: #0000CC; }\n"
+            + "    p, address {margin-left: 3em;}\n" + "    span {font-size: smaller;}\n" + "/*]]>*/--></style>\n"
+            + "</head>\n" + "\n" + "<body>\n" + "</body>\n" + "</html>\n");
+    }
+
+    @Test
+    public void withNoFacade_withUnhandledStatus_messageIsRawMessage() {
+        final HttpStatus status = HttpStatus.FAILED_DEPENDENCY;
+        assertPar(new PubmedArticleResult(null, status, "foo\nbar"), null, "Status 424 FAILED_DEPENDENCY: foo\nbar");
+        assertPar(new PubmedArticleResult(null, status, null), null, "Status 424 FAILED_DEPENDENCY");
+    }
+
+}

--- a/implementation/scipamato/scipamato-core-pubmed-api/src/test/java/ch/difty/scipamato/core/pubmed/PubmedXmlServiceIntegrationAdHocTest.java
+++ b/implementation/scipamato/scipamato-core-pubmed-api/src/test/java/ch/difty/scipamato/core/pubmed/PubmedXmlServiceIntegrationAdHocTest.java
@@ -2,8 +2,6 @@ package ch.difty.scipamato.core.pubmed;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +20,6 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @SpringBootTest
 @RunWith(SpringRunner.class)
-@SuppressWarnings("OptionalGetWithoutIsPresent")
 public class PubmedXmlServiceIntegrationAdHocTest {
 
     @Autowired
@@ -30,29 +27,32 @@ public class PubmedXmlServiceIntegrationAdHocTest {
 
     // https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=25395026&retmode=xml&version=2.0
     @Test
-    public void gettingArticleFromPubmed_withValidPmId_returnsArticle() {
+    public void gettingArticleFromPubmed_withValidPmId_returnsArticleAndNoMessage() {
         final int pmId = 25395026;
 
-        final Optional<PubmedArticleFacade> article = service.getPubmedArticleWithPmid(pmId);
-        assertThat(article.isPresent()).isTrue();
-        ScipamatoPubmedArticleIntegrationTest.assertArticle239026(article.get());
+        final PubmedArticleResult result = service.getPubmedArticleWithPmid(pmId);
+        assertThat(result.getPubmedArticleFacade()).isNotNull();
+        assertThat(result.getErrorMessage()).isNull();
+        ScipamatoPubmedArticleIntegrationTest.assertArticle239026(result.getPubmedArticleFacade());
     }
 
     @Test
-    public void gettingArticleFromPubmed_withNotExistingPmId_returnsEmptyOptional() {
+    public void gettingArticleFromPubmed_withNotExistingPmId_returnsNoArticle() {
         final int pmId = 999999999;
 
-        final Optional<PubmedArticleFacade> article = service.getPubmedArticleWithPmid(pmId);
-        assertThat(article.isPresent()).isFalse();
+        final PubmedArticleResult result = service.getPubmedArticleWithPmid(pmId);
+        assertThat(result.getPubmedArticleFacade()).isNull();
+        assertThat(result.getErrorMessage()).isEqualTo("PMID " + pmId + " seems to be undefined in PubMed.");
     }
 
     // https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=xxx,db=pubmed&id=25395026&retmode=xml&version=2.0
     @Test
     public void gettingArticleFromPubmed_withValidPmIdButInvalidApiKey_returnsNoting() {
         final int pmId = 25395026;
-        final String apiKey="xxx";
+        final String apiKey = "xxx";
 
-        final Optional<PubmedArticleFacade> article = service.getPubmedArticleWithPmidAndApiKey(pmId, apiKey);
-        assertThat(article.isPresent()).isFalse();
+        final PubmedArticleResult result = service.getPubmedArticleWithPmidAndApiKey(pmId, apiKey);
+        assertThat(result.getPubmedArticleFacade()).isNull();
+        assertThat(result.getErrorMessage()).isEqualTo("Status 400 BAD_REQUEST: API key invalid");
     }
 }

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel.properties
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel.properties
@@ -29,7 +29,7 @@ pubmedRetrieval.label=PubMed
 pubmedRetrieval.title=Sets or compares relevant fields from PubMed. PMID is required.
 pubmedRetrieval.title.disabled=Enter PMID in order to query PubMed
 pubmedRetrieval.pmid.missing=Cannot retrieve the PubMed article without first specifying the PMID.
-pubmedRetrieval.pmid.error=Could not retrieve an article with PMID ${pmId} from PubMed.
+pubmedRetrieval.pmid.error=Could not retrieve an article with PMID ${pmId} from PubMed: {0}
 pubmedRetrieval.no-difference.info=All compared fields are matching those in PubMed.
 pubmedRetrieval.dirty.info=Some fields have changed ({0}). Click save if you want to keep the changes.
 

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel_de.properties
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel_de.properties
@@ -29,7 +29,7 @@ pubmedRetrieval.label=PubMed
 pubmedRetrieval.title=Importiert oder vergleicht relevante Felder von PubMed. Ben\u00F6tigt PMID.
 pubmedRetrieval.title.disabled=Erfasse PMID, um Pubmed abzufragen
 pubmedRetrieval.pmid.missing=Der Artikel kann bei fehlender PMID nicht von PubMed abgerufen werden.
-pubmedRetrieval.pmid.error=Beim Abrufen des Artikels mit der PMID ${pmId} von PubMed ist ein Fehler aufgetreten. 
+pubmedRetrieval.pmid.error=Beim Abrufen des Artikels mit der PMID ${pmId} von PubMed ist ein Fehler aufgetreten: {0}
 pubmedRetrieval.no-difference.info=Die verglichenen Felder entsprechen jenen in PubMed.
 pubmedRetrieval.dirty.info=Einige Felder wurden ver\u00E4ndert ({0}). Bitte 'Speichern' anklicken, um die \u00C4nderungen zu sichern.
 

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/entry/EditablePaperPanel.java
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/paper/entry/EditablePaperPanel.java
@@ -56,6 +56,7 @@ import ch.difty.scipamato.core.logic.parsing.AuthorParserFactory;
 import ch.difty.scipamato.core.persistence.NewsletterService;
 import ch.difty.scipamato.core.persistence.PaperService;
 import ch.difty.scipamato.core.pubmed.PubmedArticleFacade;
+import ch.difty.scipamato.core.pubmed.PubmedArticleResult;
 import ch.difty.scipamato.core.pubmed.PubmedArticleService;
 import ch.difty.scipamato.core.web.common.BasePage;
 import ch.difty.scipamato.core.web.paper.NewsletterChangeEvent;
@@ -326,18 +327,20 @@ public abstract class EditablePaperPanel extends PaperPanel<Paper> {
         final Integer pmId = paper.getPmId();
         final String apiKey = getProperties().getPubmedApiKey();
         if (pmId != null) {
-            final Optional<PubmedArticleFacade> pao = (apiKey == null) ?
+            final PubmedArticleResult par = (apiKey == null) ?
                 pubmedArticleService.getPubmedArticleWithPmid(pmId) :
                 pubmedArticleService.getPubmedArticleWithPmidAndApiKey(pmId, apiKey);
-            if (pao.isPresent()) {
-                final PubmedArticleFacade pa = pao.get();
+            if (par.getPubmedArticleFacade() != null) {
+                final PubmedArticleFacade pa = par.getPubmedArticleFacade();
                 if (String
                     .valueOf(pmId)
                     .equals(pa.getPmId())) {
                     setFieldsIfNotSetCompareOtherwise(paper, pa, target);
                 }
             } else {
-                error(new StringResourceModel("pubmedRetrieval.pmid.error", this, getModel()).getString());
+                error(new StringResourceModel("pubmedRetrieval.pmid.error", this, getModel())
+                    .setParameters(par.getErrorMessage())
+                    .getString());
             }
         } else {
             error(new StringResourceModel("pubmedRetrieval.pmid.missing", this, null).getString());


### PR DESCRIPTION
…is unable to retrieve an article

* Feed the exception message (or parts in case of well defined
  scenarios) into the user feedback message.
* If more scenarios occur in the wild, we can adapt the methods to
  handle those more neatly too.

Fixes #48 