### PR TITLE
Bug/51 newsletter edit disable

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -72,6 +72,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 - {url-issues}44[#44] - Core & Public: Fix typo in Code '4H' (en): cardovascular -> cardiovascular
 - {url-issues}46[#46] - Sync: Fix exception (NPE) when synchronizing NewStudyTopics from Core to Public
 - {url-issues}48[#48] - Core: Provide better feedback about the underlying cause if the PubMed API is unable to retrieve an article
+- {url-issues}51[#51] - Core: Newsletter Edit Page: Issue and Issue Date only enabled for newsletters in status `In Progress`
 
 .Security
 

--- a/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/newsletter/edit/NewsletterEditPage.java
+++ b/implementation/scipamato/scipamato-core-web/src/main/java/ch/difty/scipamato/core/web/newsletter/edit/NewsletterEditPage.java
@@ -131,13 +131,38 @@ public class NewsletterEditPage extends BasePage<Newsletter> {
     protected void onInitialize() {
         super.onInitialize();
         queueForm("form");
-        queueFieldAndLabel(new TextField<String>(ISSUE.getName()), new PropertyValidator<String>());
-        queueFieldAndLabel(new LocalDateTextField(ISSUE_DATE.getName(),
-            new StringResourceModel("date.format", this, null).getString()), new PropertyValidator<LocalDate>());
+        queueFieldAndLabel(newIssueField(ISSUE.getName()), new PropertyValidator<String>());
+        queueFieldAndLabel(newIssueDateField(ISSUE_DATE.getName()), new PropertyValidator<LocalDate>());
         makeAndQueuePublicationStatusSelectBox(PUBLICATION_STATUS.getName());
         queueSubmitButton("submit");
 
         makeAndQueueResultPanel("resultPanel");
+    }
+
+    private TextField<String> newIssueField(final String id) {
+        return new TextField<>(id) {
+            @Override
+            protected void onConfigure() {
+                super.onConfigure();
+                setEnabled(isInStatusInProgress());
+            }
+        };
+    }
+
+    private boolean isInStatusInProgress() {
+        return getModelObject() != null && getModelObject()
+            .getPublicationStatus()
+            .isInProgress();
+    }
+
+    private LocalDateTextField newIssueDateField(final String id) {
+        return new LocalDateTextField(id, new StringResourceModel("date.format", this, null).getString()) {
+            @Override
+            protected void onConfigure() {
+                super.onConfigure();
+                setEnabled(isInStatusInProgress());
+            }
+        };
     }
 
     private void queueSubmitButton(final String id) {

--- a/implementation/scipamato/scipamato-core-web/src/test/java/ch/difty/scipamato/core/web/newsletter/edit/NewsletterEditPageTest.java
+++ b/implementation/scipamato/scipamato-core-web/src/test/java/ch/difty/scipamato/core/web/newsletter/edit/NewsletterEditPageTest.java
@@ -14,8 +14,8 @@ import org.apache.wicket.util.tester.FormTester;
 import org.junit.After;
 import org.junit.Test;
 
-import ch.difty.scipamato.core.entity.newsletter.Newsletter;
 import ch.difty.scipamato.common.entity.newsletter.PublicationStatus;
+import ch.difty.scipamato.core.entity.newsletter.Newsletter;
 import ch.difty.scipamato.core.web.common.BasePageTest;
 import ch.difty.scipamato.core.web.paper.result.ResultPanel;
 
@@ -86,5 +86,28 @@ public class NewsletterEditPageTest extends BasePageTest<NewsletterEditPage> {
 
         getTester().assertNoErrorMessage();
         getTester().assertNoInfoMessage();
+    }
+
+    @Test
+    public void fieldsIssueAndIssueDate_areOnlyEnabledIfNewsletterIsInProgress() {
+        for (final PublicationStatus ps : PublicationStatus.values()) {
+            final Newsletter nl = Newsletter
+                .builder()
+                .issue("1804")
+                .issueDate(LocalDate.parse("2018-04-01"))
+                .publicationStatus(ps)
+                .build();
+            getTester().startPage(new NewsletterEditPage(Model.of(nl)));
+            getTester().assertRenderedPage(NewsletterEditPage.class);
+
+            String b = "form:";
+            if (ps.isInProgress()) {
+                getTester().assertEnabled(b + "issue");
+                getTester().assertEnabled(b + "issueDate");
+            } else {
+                getTester().assertDisabled(b + "issue");
+                getTester().assertDisabled(b + "issueDate");
+            }
+        }
     }
 }


### PR DESCRIPTION
In the Newsletter Edit Page, the fields `Issue` and `Issue Date` are only editable if the newsletter is in status `In Progress`.

Several fixes in the wiki regarding newsletter management.

Fixes #51.