### PR TITLE
Bug/52 direct link to newsletter details

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 - {url-issues}46[#46] - Sync: Fix exception (NPE) when synchronizing NewStudyTopics from Core to Public
 - {url-issues}48[#48] - Core: Provide better feedback about the underlying cause if the PubMed API is unable to retrieve an article
 - {url-issues}51[#51] - Core: Newsletter Edit Page: Issue and Issue Date only enabled for newsletters in status `In Progress`
+- {url-issues}52[#52] - Public: Fix direct access to paper detail page via page parameters
 
 .Security
 

--- a/implementation/scipamato/scipamato-public-web/src/main/java/ch/difty/scipamato/publ/web/paper/browse/PublicPaperDetailPage.java
+++ b/implementation/scipamato/scipamato-public-web/src/main/java/ch/difty/scipamato/publ/web/paper/browse/PublicPaperDetailPage.java
@@ -44,11 +44,14 @@ public class PublicPaperDetailPage extends BasePage<PublicPaper> {
      * Loads the page with the record specified by the 'id' passed in via
      * PageParameters. If the parameter 'no' contains a valid business key number
      * instead, the page will be loaded by number.
+     * <p>
+     * This method has to be public, otherwise direct access via page parameters does not work.
      *
      * @param parameters
      *     page parameters
      */
-    PublicPaperDetailPage(final PageParameters parameters) {
+    @SuppressWarnings("WeakerAccess")
+    public PublicPaperDetailPage(final PageParameters parameters) {
         this(parameters, null);
     }
 


### PR DESCRIPTION
In the Newsletter Edit Page, the fields `Issue` and `Issue Date` are only editable if the newsletter is in status `In Progress`.

Several fixes in the wiki regarding newsletter management.

Fixes #52.