### PR TITLE
[2] - Core: Using Back button from PaperEntryPage breaks PDF Report generation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -71,6 +71,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Removed
 
 .Fixed
+- {url-issues}2[#2] - Core: Using Back button from PaperEntryPage breaks PDF Report generation
 - {url-issues}73[#73] - Public: Allow starting SciPaMaTo-Public in development profile
 
 .Security


### PR DESCRIPTION
* Issuing a submit from the paper entry page (e.g. by using prev/next
  button, creating a pdf or retrieving data from pubmed) and
  subsequently using the applications or the browsers back button to
  return to the calling page (PaperListPage or PaperSearchCriteriaPage)
  resulted in a NPE when clicking one of the PDF buttons in the Result
  Panel.
* Apparently, deserializing the PaperPanel rendered the reportSources
  report null. This isn't handled gracefully by JRFiller and results
  in the NPE.
* The work around for this is recreate the ResourceLinks for the PDFs
  after calling defaultReadObject within readObject of the Panel.