### PR TITLE
scipamato-core-sync: raise max-lifetime and remove idle-timout in hikari configuration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Fixed
 - {url-issues}2[#2] - Core: Using Back button from PaperEntryPage breaks PDF Report generation
 - {url-issues}73[#73] - Public: Allow starting SciPaMaTo-Public in development profile
+- {url-issues}12[#12] - Core-Sync: Improve Hikari configuration
 
 .Security
 

--- a/implementation/scipamato/scipamato-core-sync/src/main/resources/application.properties
+++ b/implementation/scipamato/scipamato-core-sync/src/main/resources/application.properties
@@ -26,8 +26,7 @@ sync.batch.datasource.password=scipamadmin
 sync.batch.datasource.pool-name=SciPaMaTo-Batch-HikariCP
 sync.batch.datasource.maximum-pool-size=3
 sync.batch.datasource.connection-timeout=10000
-sync.batch.datasource.idle-timeout=10000
-sync.batch.datasource.max-lifetime=10000
+sync.batch.datasource.max-lifetime=30000
 
 sync.source.datasource.type=${sync.batch.datasource.type}
 sync.source.datasource.driver-class-name=org.postgresql.Driver
@@ -37,8 +36,7 @@ sync.source.datasource.password=scipamato
 sync.source.datasource.pool-name=SciPaMaTo-Source-HikariCP
 sync.source.datasource.maximum-pool-size=5
 sync.source.datasource.connection-timeout=10000
-sync.source.datasource.idle-timeout=10000
-sync.source.datasource.max-lifetime=10000
+sync.source.datasource.max-lifetime=30000
 
 sync.target.datasource.type=${sync.batch.datasource.type}
 sync.target.datasource.driver-class-name=org.postgresql.Driver
@@ -48,8 +46,7 @@ sync.target.datasource.password=scipamadminpub
 sync.target.datasource.pool-name=SciPaMaTo-Target-HikariCP
 sync.target.datasource.connection-timeout=10000
 sync.target.datasource.maximum-pool-size=3
-sync.target.datasource.idle-timeout=10000
-sync.target.datasource.max-lifetime=10000
+sync.target.datasource.max-lifetime=30000
 
 
 #

--- a/implementation/scipamato/scipamato-core-sync/src/test/resources/application.properties
+++ b/implementation/scipamato/scipamato-core-sync/src/test/resources/application.properties
@@ -29,8 +29,7 @@ sync.batch.datasource.password=scipamadmin
 sync.batch.datasource.pool-name=SciPaMaTo-Batch-HikariCP
 sync.batch.datasource.maximum-pool-size=3
 sync.batch.datasource.connection-timeout=10000
-sync.batch.datasource.idle-timeout=10000
-sync.batch.datasource.max-lifetime=10000
+sync.batch.datasource.max-lifetime=30000
 
 sync.source.datasource.type=${sync.batch.datasource.type}
 sync.source.datasource.driver-class-name=${sync.batch.datasource.driver-class-name}
@@ -40,8 +39,7 @@ sync.source.datasource.password=scipamato
 sync.source.datasource.pool-name=SciPaMaTo-Source-HikariCP
 sync.source.datasource.maximum-pool-size=5
 sync.source.datasource.connection-timeout=10000
-sync.source.datasource.idle-timeout=10000
-sync.source.datasource.max-lifetime=10000
+sync.source.datasource.max-lifetime=30000
 
 sync.target.datasource.type=${sync.batch.datasource.type}
 sync.target.datasource.driver-class-name=${sync.batch.datasource.driver-class-name}
@@ -51,8 +49,7 @@ sync.target.datasource.password=scipamadminpub
 sync.target.datasource.pool-name=SciPaMaTo-Target-HikariCP
 sync.target.datasource.maximum-pool-size=3
 sync.target.datasource.connection-timeout=10000
-sync.target.datasource.idle-timeout=10000
-sync.target.datasource.max-lifetime=10000
+sync.target.datasource.max-lifetime=30000
 
 
 #


### PR DESCRIPTION
Hikari was already used in `scipamato-core-sync`.

The config was ok, but could be improved to omit some warnings:
- raise `max-lifetime` to 30000 to avoid warning
- remove `idle-timeout`, which is not active in a fixed sized pool anyhow.