### PR TITLE
Bug/70 newsletter by topic

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -69,6 +69,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Removed
 
 .Fixed
+- {url-issues}70[#70] - Core: Filter Newsletters by newsletter topic - fix query
 
 .Security
 

--- a/implementation/scipamato/scipamato-core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/newsletter/NewsletterFilterConditionMapper.java
+++ b/implementation/scipamato/scipamato-core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/newsletter/NewsletterFilterConditionMapper.java
@@ -1,7 +1,7 @@
 package ch.difty.scipamato.core.persistence.newsletter;
 
 import static ch.difty.scipamato.core.db.tables.Newsletter.NEWSLETTER;
-import static ch.difty.scipamato.core.db.tables.NewsletterNewsletterTopic.NEWSLETTER_NEWSLETTER_TOPIC;
+import static ch.difty.scipamato.core.db.tables.PaperNewsletter.PAPER_NEWSLETTER;
 
 import java.util.List;
 
@@ -36,10 +36,9 @@ public class NewsletterFilterConditionMapper extends AbstractFilterConditionMapp
                                                        .getNewsletterTopic()
                                                        .getId() != null) {
             conditions.add(NEWSLETTER.ID.in(DSL
-                .select(NEWSLETTER_NEWSLETTER_TOPIC.NEWSLETTER_ID)
-                .from(NEWSLETTER_NEWSLETTER_TOPIC)
-                .where(NEWSLETTER_NEWSLETTER_TOPIC.NEWSLETTER_ID.eq(NEWSLETTER.ID))
-                .and(NEWSLETTER_NEWSLETTER_TOPIC.NEWSLETTER_TOPIC_ID.eq(DSL.val(filter
+                .select(PAPER_NEWSLETTER.NEWSLETTER_ID)
+                .from(PAPER_NEWSLETTER)
+                .where(PAPER_NEWSLETTER.NEWSLETTER_TOPIC_ID.eq(DSL.val(filter
                     .getNewsletterTopic()
                     .getId())))));
         }

--- a/implementation/scipamato/scipamato-core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/newsletter/NewsletterFilterConditionMapper.java
+++ b/implementation/scipamato/scipamato-core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/newsletter/NewsletterFilterConditionMapper.java
@@ -8,13 +8,14 @@ import java.util.List;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
 
+import ch.difty.scipamato.common.entity.newsletter.PublicationStatus;
 import ch.difty.scipamato.common.persistence.AbstractFilterConditionMapper;
 import ch.difty.scipamato.common.persistence.FilterConditionMapper;
 import ch.difty.scipamato.core.entity.newsletter.NewsletterFilter;
+import ch.difty.scipamato.core.entity.newsletter.NewsletterTopic;
 
 /**
- * Mapper turning the provider {@link NewsletterFilter} into a jOOQ
- * {@link Condition}.
+ * Mapper turning the provider {@link NewsletterFilter} into a jOOQ {@link Condition}.
  *
  * @author u.joss
  */
@@ -23,24 +24,23 @@ public class NewsletterFilterConditionMapper extends AbstractFilterConditionMapp
 
     @Override
     public void map(final NewsletterFilter filter, final List<Condition> conditions) {
-        if (filter.getIssueMask() != null) {
-            final String likeExpression = "%" + filter.getIssueMask() + "%";
+        final String issueMask = filter.getIssueMask();
+        if (issueMask != null) {
+            final String likeExpression = "%" + issueMask + "%";
             conditions.add(NEWSLETTER.ISSUE.likeIgnoreCase(likeExpression));
         }
-        if (filter.getPublicationStatus() != null) {
-            conditions.add(NEWSLETTER.PUBLICATION_STATUS.eq(filter
-                .getPublicationStatus()
-                .getId()));
+
+        final PublicationStatus publicationStatus = filter.getPublicationStatus();
+        if (publicationStatus != null) {
+            conditions.add(NEWSLETTER.PUBLICATION_STATUS.eq(publicationStatus.getId()));
         }
-        if (filter.getNewsletterTopic() != null && filter
-                                                       .getNewsletterTopic()
-                                                       .getId() != null) {
+
+        final NewsletterTopic newsletterTopic = filter.getNewsletterTopic();
+        if (newsletterTopic != null && newsletterTopic.getId() != null) {
             conditions.add(NEWSLETTER.ID.in(DSL
                 .select(PAPER_NEWSLETTER.NEWSLETTER_ID)
                 .from(PAPER_NEWSLETTER)
-                .where(PAPER_NEWSLETTER.NEWSLETTER_TOPIC_ID.eq(DSL.val(filter
-                    .getNewsletterTopic()
-                    .getId())))));
+                .where(PAPER_NEWSLETTER.NEWSLETTER_TOPIC_ID.eq(DSL.val(newsletterTopic.getId())))));
         }
     }
 

--- a/implementation/scipamato/scipamato-core-persistence-jooq/src/test/java/ch/difty/scipamato/core/persistence/newsletter/NewsletterFilterConditionMapperTest.java
+++ b/implementation/scipamato/scipamato-core-persistence-jooq/src/test/java/ch/difty/scipamato/core/persistence/newsletter/NewsletterFilterConditionMapperTest.java
@@ -60,12 +60,10 @@ public class NewsletterFilterConditionMapperTest
             .toString()).isEqualToIgnoringCase(
             //@formatter:off
                   "\"public\".\"newsletter\".\"id\" in (\n"
-                + "  select \"public\".\"newsletter_newsletter_topic\".\"newsletter_id\"\n"
-                + "  from \"public\".\"newsletter_newsletter_topic\"\n"
-                + "  where (\n"
-                + "    \"public\".\"newsletter_newsletter_topic\".\"newsletter_id\" = \"public\".\"newsletter\".\"id\"\n"
-                + "    and \"public\".\"newsletter_newsletter_topic\".\"newsletter_topic_id\" = 5\n"
-                + "  )\n" + ")");
+                + "  select \"public\".\"paper_newsletter\".\"newsletter_id\"\n"
+                + "  from \"public\".\"paper_newsletter\"\n"
+                + "  where \"public\".\"paper_newsletter\".\"newsletter_topic_id\" = 5\n"
+                + ")");
             //@formatter:on
     }
 


### PR DESCRIPTION
The table `newsletter_newsletter_topic` was used to query newsletters by newsletter topic. However, this table is not necessarily populated with data for all newsletters. It only contains records if the default sort order of the topics was changed.

Instead, the query should be based upon `paper_newsletter` that always contains the relevant records.