### PR TITLE
[105] - Sort search orders by id desc and show top 200 instead of 20

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -70,6 +70,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Removed
 
 .Fixed
+- {url-issues}105[#105] Core - Restore ability to create new searches with more than 20 saved searches
 
 .Security
 

--- a/implementation/scipamato/core/web/src/main/java/ch/difty/scipamato/core/web/model/SearchOrderModel.java
+++ b/implementation/scipamato/core/web/src/main/java/ch/difty/scipamato/core/web/model/SearchOrderModel.java
@@ -38,7 +38,7 @@ public class SearchOrderModel extends InjectedLoadableDetachableModel<SearchOrde
     protected List<SearchOrder> load() {
         final SearchOrderFilter filter = new SearchOrderFilter();
         filter.setOwnerIncludingGlobal(owner);
-        final PaginationContext pc = new PaginationRequest(0, maxRows, Direction.ASC, "global");
+        final PaginationContext pc = new PaginationRequest(0, maxRows, Direction.DESC, "id");
         return service.findPageByFilter(filter, pc);
     }
 

--- a/implementation/scipamato/core/web/src/main/java/ch/difty/scipamato/core/web/paper/search/SearchOrderSelectorPanel.java
+++ b/implementation/scipamato/core/web/src/main/java/ch/difty/scipamato/core/web/paper/search/SearchOrderSelectorPanel.java
@@ -56,7 +56,7 @@ public class SearchOrderSelectorPanel extends BasePanel<SearchOrder> {
 
     // HARDCODED static number of search orders to be visible in the select box.
     // Might need to become more dynamic
-    private static final int SEARCH_ORDER_MAX = 20;
+    private static final int SEARCH_ORDER_MAX = 200;
 
     @SpringBean
     private SearchOrderService searchOrderService;

--- a/implementation/scipamato/core/web/src/test/java/ch/difty/scipamato/core/web/model/SearchOrderModelTest.java
+++ b/implementation/scipamato/core/web/src/test/java/ch/difty/scipamato/core/web/model/SearchOrderModelTest.java
@@ -61,7 +61,7 @@ class SearchOrderModelTest extends ModelTest {
     }
 
     class PaginationRequestWithMaxRows implements ArgumentMatcher<PaginationRequest> {
-        private static final String GLOBAL = "global";
+        private static final String SORT = "id";
 
         private int maxRows;
 
@@ -77,7 +77,7 @@ class SearchOrderModelTest extends ModelTest {
                     .iterator();
                 if (it.hasNext()) {
                     SortProperty sp = it.next();
-                    return GLOBAL.equals(sp.getName()) && sp
+                    return SORT.equals(sp.getName()) && !sp
                         .getDirection()
                         .isAscending();
                 }


### PR DESCRIPTION
Sorts the search orders by id descendingly and limits the search results to the top 200 instead of top 20.

Fixes #105.