### PR TITLE
Chore/improve GitHub workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,14 @@
 name: Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '*'
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
     - master
     tags:
     - '*'
+    paths:
+    - 'implementation/scipamato/*'
+
   pull_request:
     branches:
     - master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,6 +1,9 @@
 name: Sonar
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    paths:
+    - 'implementation/scipamato/*'
 
 jobs:
   build:


### PR DESCRIPTION
Hi, 

Here are small improvement for your the github workflow you may want.

The idea is to:
* Run the workflows only for the branch `master` (and pull requests against that branch)
* Run the workflows for all new pushed tags. (will run for the tagged commit, even if you push more commits alltogether)
* Run only the check tasks for changes made in `implementation/scipamato`

You can see there results here:
* workflow status and log: https://github.com/jcornaz/scipamato/actions
* sonar report: https://sonarcloud.io/dashboard?id=jcornaz_scipamato
