### PR TITLE
Chore/142 release management take2

### DIFF
--- a/implementation/scipamato/build.gradle.kts
+++ b/implementation/scipamato/build.gradle.kts
@@ -27,7 +27,6 @@ plugins {
 }
 
 java {
-    version = JavaVersion.VERSION_11
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 }

--- a/implementation/scipamato/build.gradle.kts
+++ b/implementation/scipamato/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     Lib.testSetsPlugin().run { id(id) version version }
     Lib.detektPlugin().run { id(id) version version }
     Lib.sonarqubePlugin().run { id(id) version version }
+    Lib.reckonPlugin().run { id(id) version version }
 }
 
 java {
@@ -46,9 +47,9 @@ val testModuleDirs = setOf("common/test", "common/persistence-jooq-test")
 val testModules = testModuleDirs.map { it.replaceFirst("/", "-") }
 val testPackages = testModuleDirs.map { "$it/**/*" }
 val generatedPackages: Set<String> = setOf(
-        "**/ch/difty/scipamato/core/db/**",
-        "**/ch/difty/scipamato/core/pubmed/api/**",
-        "**/ch/difty/scipamato/publ/db/**"
+    "**/ch/difty/scipamato/core/db/**",
+    "**/ch/difty/scipamato/core/pubmed/api/**",
+    "**/ch/difty/scipamato/publ/db/**"
 )
 
 val jacocoTestReportFile = "$buildDir/reports/jacoco/test/jacocoTestReport.xml"
@@ -67,9 +68,13 @@ sonarqube {
     }
 }
 
+reckon {
+    scopeFromProp()
+    snapshotFromProp()
+}
+
 allprojects {
     group = "ch.difty"
-    version = "1.3.2-SNAPSHOT"
 
     repositories {
         mavenLocal()
@@ -213,6 +218,12 @@ subprojects {
                 })))
             }
             dependsOn(check)
+        }
+
+        register("version") {
+            doLast {
+                println(project.version)
+            }
         }
     }
 }

--- a/implementation/scipamato/buildSrc/src/main/kotlin/Lib.kt
+++ b/implementation/scipamato/buildSrc/src/main/kotlin/Lib.kt
@@ -60,6 +60,7 @@ object Lib {
     private const val springDependencyManagementPluginVersion = "1.0.8.RELEASE"
     private const val lombokPluginVersion = "4.1.2"
     private const val jooqModelatorPluginVersion = "3.6.0"
+    private const val reckonPluginVersion = "0.11.0"
     private const val jaxbPluginVersion = "3.0.4"
     private const val testSetsPluginVersion = "2.2.1"
     private const val sonarqubePluginVersion = "2.8"
@@ -171,6 +172,8 @@ object Lib {
     fun jooqModelatorPlugin() = Plugin("ch.ayedo.jooqmodelator", jooqModelatorPluginVersion)
 
     fun testSetsPlugin() = Plugin("org.unbroken-dome.test-sets", testSetsPluginVersion)
+
+    fun reckonPlugin() = Plugin("org.ajoberstar.reckon", reckonPluginVersion)
 
     fun jaxbPlugin() = Plugin("com.intershop.gradle.jaxb", jaxbPluginVersion)
 


### PR DESCRIPTION
Introduces [reckon](https://github.com/ajoberstar/reckon) for version management.

I ran into an issue with the following error message:

```
Could not evaluate onlyIf predicate for task ':reckonTagCreate'.
> class org.gradle.api.JavaVersion cannot be cast to class org.ajoberstar.reckon.gradle.ReckonPlugin$DelayedVersion (org.gradle.api.JavaVersion is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @2b98378d; org.ajoberstar.reckon.gradle.ReckonPlugin$DelayedVersion is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @3b891ab3)
```

It turned out the following configuration in my `build.gradle.kts` was responsible for it:

```
java {
    version = JavaVersion.VERSION_11
    sourceCompatibility = JavaVersion.VERSION_11
    targetCompatibility = JavaVersion.VERSION_11
}
```

Removing the first line in the java lambda (`version = `) resolved the issue but was relatively tricky to find...