### PR TITLE
Clean up build.gradle.kts of persistance-jooq projects

### DIFF
--- a/core/core-persistence-jooq/src/integration-test/resources/application.properties
+++ b/core/core-persistence-jooq/src/integration-test/resources/application.properties
@@ -7,11 +7,12 @@ spring.datasource.continue-on-error=true
 spring.jooq.sql-dialect=Postgres
 db.schema=public
 db.name=scipamato
+db.port=5432
 
 # we need the driver-class-name to trigger the creation of a connection pool
 # see https://github.com/spring-projects/spring-boot/issues/6907
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:10.6://localhost:5432/${db.name}
+spring.datasource.url=jdbc:tc:postgresql:10.6://localhost:${db.port}/${db.name}
 
 spring.datasource.hikari.driver-class-name=${spring.datasource.driver-class-name}
 spring.datasource.hikari.jdbc-url=${spring.datasource.url}

--- a/public/public-persistence-jooq/src/integration-test/resources/application.properties
+++ b/public/public-persistence-jooq/src/integration-test/resources/application.properties
@@ -7,11 +7,12 @@ spring.datasource.continue-on-error=true
 spring.jooq.sql-dialect=Postgres
 db.schema=public
 db.name=scipamato_public
+db.port=5432
 
 # we need the driver-class-name to trigger the creation of a connection pool
 # see https://github.com/spring-projects/spring-boot/issues/6907
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:10.6://localhost:5432/${db.name}
+spring.datasource.url=jdbc:tc:postgresql:10.6://localhost:${db.port}/${db.name}
 
 spring.datasource.hikari.driver-class-name=${spring.datasource.driver-class-name}
 spring.datasource.hikari.jdbc-url=${spring.datasource.url}


### PR DESCRIPTION
- remove redundancy between generated `jooqConfig.xml` file and gradle jooqModelator config
- remove obsolete warnings about keeping related configuration in sync