### PR TITLE
[238] SciPaMaTo-Public: Hide Back-Button from paper detail page when opened from result panel

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -74,7 +74,8 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 - {url-issues}236[#236] Prepopulate field 'result exposure range' with value 'µg/m3' for new papers
 
 .Changed
-- Follow up of {url-issues}215[#215]: Enlarge PMID field, make DOI smaller on smaller screens 
+- Follow up of {url-issues}215[#215]: Enlarge PMID field, make DOI smaller on smaller screens
+- {url-issues}238[#238] SciPaMaTo-Public: Hide 'Back' button from paper detail page when opend from result panel
 
 ////
 .Deprecated

--- a/public/public-web/src/main/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPage.kt
+++ b/public/public-web/src/main/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPage.kt
@@ -233,7 +233,7 @@ class PublicPage(parameters: PageParameters) : BasePage<Void>(parameters) {
      */
     private fun onTitleClick(m: IModel<PublicPaper>) {
         m.getObject().number?.let { paperIdManager.setFocusToItem(it) }
-        setResponsePage(PublicPaperDetailPage(m, page.pageReference))
+        setResponsePage(PublicPaperDetailPage(m, page.pageReference, showBackButton = false))
     }
 
     /**

--- a/public/public-web/src/main/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPaperDetailPage.kt
+++ b/public/public-web/src/main/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPaperDetailPage.kt
@@ -32,22 +32,23 @@ class PublicPaperDetailPage : BasePage<PublicPaper> {
     private lateinit var publicPaperService: PublicPaperService
 
     private val callingPageRef: PageReference?
+    private val showBackButton: Boolean
 
     /**
      * Loads the page with the record specified by the 'id' passed in via
      * PageParameters. If the parameter 'no' contains a valid business key number
      * instead, the page will be loaded by number.
-     *
-     * This method has to be public, otherwise direct access via page parameters does not work.
      */
     @JvmOverloads
-    constructor(parameters: PageParameters, callingPageRef: PageReference? = null) : super(parameters) {
+    constructor(parameters: PageParameters, callingPageRef: PageReference? = null, showBackButton: Boolean = true) : super(parameters) {
         this.callingPageRef = callingPageRef
+        this.showBackButton = showBackButton
         parameters.tryLoadingRecordFromNumber()
     }
 
-    internal constructor(paperModel: IModel<PublicPaper>?, callingPageRef: PageReference?) : super(paperModel) {
+    internal constructor(paperModel: IModel<PublicPaper>?, callingPageRef: PageReference?, showBackButton: Boolean = true) : super(paperModel) {
         this.callingPageRef = callingPageRef
+        this.showBackButton = showBackButton
     }
 
     private fun PageParameters.tryLoadingRecordFromNumber() {
@@ -145,6 +146,7 @@ class PublicPaperDetailPage : BasePage<PublicPaper> {
                 if (callingPageRef != null) setResponsePage(callingPageRef.page) else setResponsePage(PublicPage::class.java)
             }
         }.apply {
+            isVisible = showBackButton
             defaultFormProcessing = false
             add(AttributeModifier(
                 AM_TITLE,

--- a/public/public-web/src/test/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPageTest.kt
+++ b/public/public-web/src/test/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPageTest.kt
@@ -205,14 +205,14 @@ internal class PublicPageTest : BasePageTest<PublicPage>() {
     }
 
     @Test
-    fun clickingTitle_forwardsToDetailsPage() {
+    fun clickingTitle_forwardsToDetailsPage_whichHasNoBackButton() {
         tester.startPage(makePage())
         tester.assertRenderedPage(pageClass)
-        tester
-            .newFormTester("searchForm")
-            .submit("query")
+        tester.newFormTester("searchForm").submit("query")
         tester.clickLink("results:body:rows:1:cells:2:cell:link")
         tester.assertRenderedPage(PublicPaperDetailPage::class.java)
+
+        tester.assertInvisible("form:back")
 
         verify { paperService.countByFilter(any()) }
         verify { paperService.findPageByFilter(any(), any()) }


### PR DESCRIPTION
Resolves #238