### PR TITLE
fix: [#260] Log in to dockerhub in github actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,5 +36,11 @@ jobs:
         restore-keys: |
           gradle-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Check with Gradle
       run: ./gradlew check --stacktrace

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Download postgres
-      uses: docker://postgres:10
+      run: docker pull postgres:10
 
     - name: Check with Gradle
       run: ./gradlew check --stacktrace

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,5 +42,8 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Download postgres
+      uses: docker://postgres:10
+
     - name: Check with Gradle
       run: ./gradlew check --stacktrace

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,6 +33,9 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Download postgres
+      uses: docker://postgres:10
+
     - name: Run sonar task
       run: ./gradlew sonarqube --no-daemon
       env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -34,7 +34,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Download postgres
-      uses: docker://postgres:10
+      run: docker pull postgres:10
 
     - name: Run sonar task
       run: ./gradlew sonarqube --no-daemon

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,6 +27,12 @@ jobs:
         restore-keys: |
           gradle-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Run sonar task
       run: ./gradlew sonarqube --no-daemon
       env:


### PR DESCRIPTION
Resolves #260.

Requires an Access Token on Docker hub. Store it and the login name as github secrets `DOCKERHUB_TOKEN` and `DOCKERHUB_USERNAME`