### PR TITLE
fix: [#262] Restore ConfirmationBehavior with updated wicket-bootstrap

### DIFF
--- a/buildSrc/src/main/kotlin/Lib.kt
+++ b/buildSrc/src/main/kotlin/Lib.kt
@@ -18,7 +18,7 @@ object Lib {
     private const val wicketVersion = "9.2.0"
     private const val wicketstuffVersion = "9.2.0"
     private const val wicketJqueryUiVersion = "9.2.0"
-    private const val wicketBootstrapVersion = "4.0.2"
+    private const val wicketBootstrapVersion = "4.0.3"
     private const val jasperReportVersion = "6.16.0"
     private const val univocityParsersVersion = "2.9.1"
 

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/search/SearchOrderSelectorPanelInEditModeTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/search/SearchOrderSelectorPanelInEditModeTest.kt
@@ -2,18 +2,13 @@ package ch.difty.scipamato.core.web.paper.search
 
 import ch.difty.scipamato.common.web.Mode
 import io.mockk.verify
+import org.apache.wicket.model.Model
 import org.junit.jupiter.api.Test
 
 internal class SearchOrderSelectorPanelInEditModeTest : SearchOrderSelectorPanelTest() {
 
     override val mode: Mode
         get() = Mode.EDIT
-
-    @Test
-    fun loadingPage_withSearchOrderWithCurrentOwner_rendersGlobalCheckBoxDisabled() {
-        tester.startComponentInPage(makePanel())
-        tester.assertEnabled("$PANEL_ID:form:global")
-    }
 
     @Test
     fun withGlobalSearchOrders_withSameOwner_globalCheckBox_enabled() {
@@ -45,5 +40,47 @@ internal class SearchOrderSelectorPanelInEditModeTest : SearchOrderSelectorPanel
         searchOrder.apply { owner = OWNER_ID + 1 }
         tester.startComponentInPage(makePanel())
         tester.assertDisabled("$PANEL_ID:form:global")
+    }
+
+    @Test
+    fun deleteButton_withNoSearchSelected_isDisabled() {
+        tester.startComponentInPage(SearchOrderSelectorPanel(PANEL_ID, Model.of(), mode))
+        tester.assertDisabled("$PANEL_ID:form:delete")
+    }
+
+    @Test
+    fun deleteButton_withGlobalSearchOfOtherUserSelected_isDisabled() {
+        searchOrder.apply {
+            owner = OWNER_ID + 1
+            isGlobal = true
+        }
+        tester.startComponentInPage(makePanel())
+        tester.assertDisabled("$PANEL_ID:form:delete")
+    }
+
+
+    @Test
+    fun deleteButton_withGlobalSearchOfCurrentUserSelected_isEnabled() {
+        searchOrder.apply {
+            isGlobal = true
+        }
+        tester.startComponentInPage(makePanel())
+        tester.assertEnabled("$PANEL_ID:form:delete")
+    }
+
+    @Test
+    fun deleteButton_withLocalSearchOfCurrentUserSelected_isEnabled() {
+        tester.startComponentInPage(makePanel())
+        tester.assertEnabled("$PANEL_ID:form:delete")
+        verify(exactly = 0) { searchOrderServiceMock.remove(any()) }
+    }
+
+    @Test
+    fun deleting_doesDelete() {
+        // Why isn't it respecting the ConfirmationBehavior in the test setting?
+        tester.startComponentInPage(makePanel())
+        tester.clickLink("$PANEL_ID:form:delete")
+        verify(exactly = 1) { searchOrderServiceMock.remove(any()) }
+        tester.assertRenderedPage(PaperSearchPage::class.java)
     }
 }


### PR DESCRIPTION
Resolves #262.

ConfirmationBehavior was broken when used with bootstrap 3.4.1
(see https://github.com/l0rdn1kk0n/wicket-bootstrap/pull/895)
Bumping wicket-bootstrap to 4.0.3 will bring in the fixed version.

The additional tests cover more scenario, but unfortunately don't capture
the broken scenario (no red test in this case). I did not manage to test it.