### PR TITLE
feat(core): [#306] Population Filter & Search + some renames

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -70,6 +70,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 {url-cl}1.6.8$$...$$main[Full Changelog]
 
 .Added
+- {url-issues}306[#306] Population Filter & Search
 
 ////
 .Changed

--- a/common/common-wicket/src/main/kotlin/ch/difty/scipamato/common/web/AbstractPanel.utf8.properties
+++ b/common/common-wicket/src/main/kotlin/ch/difty/scipamato/common/web/AbstractPanel.utf8.properties
@@ -24,7 +24,7 @@ result.label=Results
 methods.label=Methods
 comment.label=Comment
 
-populationPlace.label=Place/Country (study name)
+populationPlace.label=Place/Country
 populationParticipants.label=Participants
 populationDuration.label=Study Duration
 

--- a/common/common-wicket/src/main/kotlin/ch/difty/scipamato/common/web/AbstractPanel_de.utf8.properties
+++ b/common/common-wicket/src/main/kotlin/ch/difty/scipamato/common/web/AbstractPanel_de.utf8.properties
@@ -24,7 +24,7 @@ methods.label=Methoden
 result.label=Resultate
 comment.label=Bemerkungen
 
-populationPlace.label=Ort/Land (Studie)
+populationPlace.label=Ort/Land
 populationParticipants.label=Studienteilnehmer
 populationDuration.label=Studiendauer
 

--- a/core/core-entity/src/main/java/ch/difty/scipamato/core/entity/search/PaperFilter.java
+++ b/core/core-entity/src/main/java/ch/difty/scipamato/core/entity/search/PaperFilter.java
@@ -17,6 +17,7 @@ public class PaperFilter implements ScipamatoFilter, PaperSlimFilter {
     private Long    number;
     private String  authorMask;
     private String  methodsMask;
+    private String  populationMask;
     private String  searchMask;
     private Integer publicationYearFrom;
     private Integer publicationYearUntil;
@@ -26,6 +27,7 @@ public class PaperFilter implements ScipamatoFilter, PaperSlimFilter {
         NUMBER("number"),
         AUTHOR_MASK("authorMask"),
         METHODS_MASK("methodsMask"),
+        POPULATION_MASK("populationMask"),
         SEARCH_MASK("searchMask"),
         PUB_YEAR_FROM("publicationYearFrom"),
         PUB_YEAR_UNTIL("publicationYearUntil"),

--- a/core/core-entity/src/test/kotlin/ch/difty/scipamato/core/entity/search/PaperFilterTest.kt
+++ b/core/core-entity/src/test/kotlin/ch/difty/scipamato/core/entity/search/PaperFilterTest.kt
@@ -14,6 +14,7 @@ internal class PaperFilterTest {
         f.number = 1L
         f.authorMask = "authorMask"
         f.methodsMask = "methodsMask"
+        f.populationMask = "populationMask"
         f.searchMask = "searchMask"
         f.publicationYearFrom = 2015
         f.publicationYearUntil = 2017
@@ -22,13 +23,14 @@ internal class PaperFilterTest {
         f.number shouldBeEqualTo 1L
         f.authorMask shouldBeEqualTo "authorMask"
         f.methodsMask shouldBeEqualTo "methodsMask"
+        f.populationMask shouldBeEqualTo "populationMask"
         f.searchMask shouldBeEqualTo "searchMask"
         f.publicationYearFrom shouldBeEqualTo 2015
         f.publicationYearUntil shouldBeEqualTo 2017
         f.newsletterId shouldBeEqualTo 2
 
         f.toString() shouldBeEqualTo
-            "PaperFilter(number=1, authorMask=authorMask, methodsMask=methodsMask, searchMask=searchMask, " +
+            "PaperFilter(number=1, authorMask=authorMask, methodsMask=methodsMask, populationMask=populationMask, searchMask=searchMask, " +
             "publicationYearFrom=2015, publicationYearUntil=2017, newsletterId=2)"
     }
 
@@ -46,6 +48,7 @@ internal class PaperFilterTest {
             "number",
             "authorMask",
             "methodsMask",
+            "populationMask",
             "searchMask",
             "publicationYearFrom",
             "publicationYearUntil",

--- a/core/core-persistence-jooq/src/integration-test/kotlin/ch/difty/scipamato/core/persistence/paper/searchorder/StringSearchTermEvaluatorTest.kt
+++ b/core/core-persistence-jooq/src/integration-test/kotlin/ch/difty/scipamato/core/persistence/paper/searchorder/StringSearchTermEvaluatorTest.kt
@@ -1288,4 +1288,630 @@ internal class StringSearchTermEvaluatorTest {
                |)""".trimMargin()
     }
     //endregion
+
+    //region:populationField
+    private fun expectPopulationToken(type: TokenType, term: String) {
+        every { stMock.fieldName } returns "population"
+        tokens.add(Token(type, term))
+        every { stMock.tokens } returns tokens
+    }
+
+    @Test
+    fun buildingConditionForNotRegex_withPopulationField_appliesNotRegexToAllPopulationFields() {
+        expectPopulationToken(TokenType.NOTREGEX, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  not ((lower(cast(coalesce(
+               |    population,
+               |    ''
+               |  ) as varchar)) like_regex 'foo'))
+               |  and not ((lower(cast(coalesce(
+               |    population_place,
+               |    ''
+               |  ) as varchar)) like_regex 'foo'))
+               |  and not ((lower(cast(coalesce(
+               |    population_participants,
+               |    ''
+               |  ) as varchar)) like_regex 'foo'))
+               |  and not ((lower(cast(coalesce(
+               |    population_duration,
+               |    ''
+               |  ) as varchar)) like_regex 'foo'))
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForRegex_withPopulationField_appliesRegexToAllPopulationFields() {
+        expectPopulationToken(TokenType.REGEX, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  (lower(cast(coalesce(
+               |    population,
+               |    ''
+               |  ) as varchar)) like_regex 'foo')
+               |  or (lower(cast(coalesce(
+               |    population_place,
+               |    ''
+               |  ) as varchar)) like_regex 'foo')
+               |  or (lower(cast(coalesce(
+               |    population_participants,
+               |    ''
+               |  ) as varchar)) like_regex 'foo')
+               |  or (lower(cast(coalesce(
+               |    population_duration,
+               |    ''
+               |  ) as varchar)) like_regex 'foo')
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForWhitespace_withPopulationField_appliesTrueCondition() {
+        expectPopulationToken(TokenType.WHITESPACE, "   ")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo "true"
+    }
+
+    @Test
+    fun buildingConditionForSome_withPopulationField_appliesNotEmpty() {
+        expectPopulationToken(TokenType.SOME, "whatever")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  (
+                   |    population is not null
+                   |    and char_length(cast(population as varchar)) > 0
+                   |  )
+                   |  or (
+                   |    population_place is not null
+                   |    and char_length(cast(population_place as varchar)) > 0
+                   |  )
+                   |  or (
+                   |    population_participants is not null
+                   |    and char_length(cast(population_participants as varchar)) > 0
+                   |  )
+                   |  or (
+                   |    population_duration is not null
+                   |    and char_length(cast(population_duration as varchar)) > 0
+                   |  )
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForEmpty_withPopulationField_appliesEmptyToAllPopulationFields() {
+        expectPopulationToken(TokenType.EMPTY, "whatever")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  (
+               |    population is null
+               |    or char_length(cast(population as varchar)) = 0
+               |  )
+               |  and (
+               |    population_place is null
+               |    or char_length(cast(population_place as varchar)) = 0
+               |  )
+               |  and (
+               |    population_participants is null
+               |    or char_length(cast(population_participants as varchar)) = 0
+               |  )
+               |  and (
+               |    population_duration is null
+               |    or char_length(cast(population_duration as varchar)) = 0
+               |  )
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotOpenLeftRightQuoted_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.NOTOPENLEFTRIGHTQUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  coalesce(
+               |    population,
+               |    ''
+               |  ) not ilike '%foo%'
+               |  and coalesce(
+               |    population_place,
+               |    ''
+               |  ) not ilike '%foo%'
+               |  and coalesce(
+               |    population_participants,
+               |    ''
+               |  ) not ilike '%foo%'
+               |  and coalesce(
+               |    population_duration,
+               |    ''
+               |  ) not ilike '%foo%'
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForOpenLeftRightQuoted_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.OPENLEFTRIGHTQUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  population ilike '%foo%'
+                   |  or population_place ilike '%foo%'
+                   |  or population_participants ilike '%foo%'
+                   |  or population_duration ilike '%foo%'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotOpenLeftRight_withPopulationField_appliesNotLikeToAllPolpulationFields() {
+        expectPopulationToken(TokenType.NOTOPENLEFTRIGHT, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  coalesce(
+                   |    population,
+                   |    ''
+                   |  ) not ilike '%foo%'
+                   |  and coalesce(
+                   |    population_place,
+                   |    ''
+                   |  ) not ilike '%foo%'
+                   |  and coalesce(
+                   |    population_participants,
+                   |    ''
+                   |  ) not ilike '%foo%'
+                   |  and coalesce(
+                   |    population_duration,
+                   |    ''
+                   |  ) not ilike '%foo%'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForOpenLeftRight_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.OPENLEFTRIGHT, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  population ilike '%foo%'
+                   |  or population_place ilike '%foo%'
+                   |  or population_participants ilike '%foo%'
+                   |  or population_duration ilike '%foo%'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotOpenRightQuoted_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.NOTOPENRIGHTQUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  coalesce(
+                   |    population,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |  and coalesce(
+                   |    population_place,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |  and coalesce(
+                   |    population_participants,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |  and coalesce(
+                   |    population_duration,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForOpenRightQuoted_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.OPENRIGHTQUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  population ilike 'foo%'
+                   |  or population_place ilike 'foo%'
+                   |  or population_participants ilike 'foo%'
+                   |  or population_duration ilike 'foo%'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotOpenRight_withPopulationField_appliesNotLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.NOTOPENRIGHT, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  coalesce(
+                   |    population,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |  and coalesce(
+                   |    population_place,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |  and coalesce(
+                   |    population_participants,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |  and coalesce(
+                   |    population_duration,
+                   |    ''
+                   |  ) not ilike 'foo%'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForOpenRight_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.OPENRIGHT, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  population ilike 'foo%'
+                   |  or population_place ilike 'foo%'
+                   |  or population_participants ilike 'foo%'
+                   |  or population_duration ilike 'foo%'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotOpenLeftQuoted_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.NOTOPENLEFTQUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  coalesce(
+                   |    population,
+                   |    ''
+                   |  ) not ilike '%foo'
+                   |  and coalesce(
+                   |    population_place,
+                   |    ''
+                   |  ) not ilike '%foo'
+                   |  and coalesce(
+                   |    population_participants,
+                   |    ''
+                   |  ) not ilike '%foo'
+                   |  and coalesce(
+                   |    population_duration,
+                   |    ''
+                   |  ) not ilike '%foo'
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForOpenLeftQuoted_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.OPENLEFTQUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  population ilike '%foo'
+               |  or population_place ilike '%foo'
+               |  or population_participants ilike '%foo'
+               |  or population_duration ilike '%foo'
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotOpenLeft_withPopulationField_appliesNotLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.NOTOPENLEFT, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  coalesce(
+               |    population,
+               |    ''
+               |  ) not ilike '%foo'
+               |  and coalesce(
+               |    population_place,
+               |    ''
+               |  ) not ilike '%foo'
+               |  and coalesce(
+               |    population_participants,
+               |    ''
+               |  ) not ilike '%foo'
+               |  and coalesce(
+               |    population_duration,
+               |    ''
+               |  ) not ilike '%foo'
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForOpenLeft_withPopulationField_appliesLikeToAllPopulationFields() {
+        expectPopulationToken(TokenType.OPENLEFT, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  population ilike '%foo'
+               |  or population_place ilike '%foo'
+               |  or population_participants ilike '%foo'
+               |  or population_duration ilike '%foo'
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotQuoted_withParticipantsField_appliesUnequalToAllParticipantsFields() {
+        expectPopulationToken(TokenType.NOTQUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  lower(cast(population as varchar)) <> lower('foo')
+                   |  and lower(cast(population_place as varchar)) <> lower('foo')
+                   |  and lower(cast(population_participants as varchar)) <> lower('foo')
+                   |  and lower(cast(population_duration as varchar)) <> lower('foo')
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForQuoted_withParticipantsField_appliesEqualToAllParticipantsFields() {
+        expectPopulationToken(TokenType.QUOTED, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+                   |  lower(cast(population as varchar)) = lower('foo')
+                   |  or lower(cast(population_place as varchar)) = lower('foo')
+                   |  or lower(cast(population_participants as varchar)) = lower('foo')
+                   |  or lower(cast(population_duration as varchar)) = lower('foo')
+                   |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForNotWord_withPopulationField_appliesNotContainsToAllPopulationFields() {
+        expectPopulationToken(TokenType.NOTWORD, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  not (coalesce(
+               |    population,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |  and not (coalesce(
+               |    population_place,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |  and not (coalesce(
+               |    population_participants,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |  and not (coalesce(
+               |    population_duration,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForWord_withPopulationField_appliesContainsToAllPopulationFields() {
+        expectPopulationToken(TokenType.WORD, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo
+            """(
+               |  population ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!'
+               |  or population_place ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!'
+               |  or population_participants ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!'
+               |  or population_duration ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'foo',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!'
+               |)""".trimMargin()
+    }
+
+    @Test
+    fun buildingConditionForRaw_withPopulationField_appliesDummyTrue() {
+        expectPopulationToken(TokenType.RAW, "foo")
+        evaluator.evaluate(stMock).toString() shouldBeEqualTo "true"
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    @Test
+    fun buildingConditionForUnsupported_withPopulationField_throws() {
+        expectPopulationToken(TokenType.UNSUPPORTED, "foo")
+        invoking { evaluator.evaluate(stMock) } shouldThrow AssertionError::class withMessage
+            "Evaluation of type UNSUPPORTED is not supported..."
+    }
+
+    @Test
+    fun buildingConditionForCombinedSearchTerm_withPopulationField_() {
+        val sst = SearchTerm.newSearchTerm(
+            1L, SearchTermType.STRING.id, 1L,
+            "population", "foo -bar"
+        ) as StringSearchTerm
+        evaluator.evaluate(sst).toString() shouldBeEqualTo
+            """(
+               |  (
+               |    population ilike ('%' || replace(
+               |      replace(
+               |        replace(
+               |          'foo',
+               |          '!',
+               |          '!!'
+               |        ),
+               |        '%',
+               |        '!%'
+               |      ),
+               |      '_',
+               |      '!_'
+               |    ) || '%') escape '!'
+               |    or population_place ilike ('%' || replace(
+               |      replace(
+               |        replace(
+               |          'foo',
+               |          '!',
+               |          '!!'
+               |        ),
+               |        '%',
+               |        '!%'
+               |      ),
+               |      '_',
+               |      '!_'
+               |    ) || '%') escape '!'
+               |    or population_participants ilike ('%' || replace(
+               |      replace(
+               |        replace(
+               |          'foo',
+               |          '!',
+               |          '!!'
+               |        ),
+               |        '%',
+               |        '!%'
+               |      ),
+               |      '_',
+               |      '!_'
+               |    ) || '%') escape '!'
+               |    or population_duration ilike ('%' || replace(
+               |      replace(
+               |        replace(
+               |          'foo',
+               |          '!',
+               |          '!!'
+               |        ),
+               |        '%',
+               |        '!%'
+               |      ),
+               |      '_',
+               |      '!_'
+               |    ) || '%') escape '!'
+               |  )
+               |  and not (coalesce(
+               |    population,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'bar',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |  and not (coalesce(
+               |    population_place,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'bar',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |  and not (coalesce(
+               |    population_participants,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'bar',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |  and not (coalesce(
+               |    population_duration,
+               |    ''
+               |  ) ilike ('%' || replace(
+               |    replace(
+               |      replace(
+               |        'bar',
+               |        '!',
+               |        '!!'
+               |      ),
+               |      '%',
+               |      '!%'
+               |    ),
+               |    '_',
+               |    '!_'
+               |  ) || '%') escape '!')
+               |)""".trimMargin()
+    }
+    //endregion
+
 }

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/PaperFilterConditionMapper.kt
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/PaperFilterConditionMapper.kt
@@ -37,6 +37,15 @@ class PaperFilterConditionMapper : AbstractFilterConditionMapper<PaperFilter>() 
                     .or(Paper.PAPER.POPULATION_PLACE.likeIgnoreCase(likeExpression))
             )
         }
+        filter.populationMask?.let {
+            val likeExpression = "%$it%"
+            conditions.add(
+                Paper.PAPER.POPULATION.likeIgnoreCase(likeExpression)
+                    .or(Paper.PAPER.POPULATION_PLACE.likeIgnoreCase(likeExpression))
+                    .or(Paper.PAPER.POPULATION_PARTICIPANTS.likeIgnoreCase(likeExpression))
+                    .or(Paper.PAPER.POPULATION_DURATION.likeIgnoreCase(likeExpression))
+            )
+        }
         filter.searchMask?.let {
             val likeExpression = "%$it%"
             conditions.add(
@@ -44,9 +53,6 @@ class PaperFilterConditionMapper : AbstractFilterConditionMapper<PaperFilter>() 
                     .or(Paper.PAPER.LOCATION.likeIgnoreCase(likeExpression))
                     .or(Paper.PAPER.TITLE.likeIgnoreCase(likeExpression))
                     .or(Paper.PAPER.GOALS.likeIgnoreCase(likeExpression))
-                    .or(Paper.PAPER.POPULATION.likeIgnoreCase(likeExpression))
-                    .or(Paper.PAPER.POPULATION_PARTICIPANTS.likeIgnoreCase(likeExpression))
-                    .or(Paper.PAPER.POPULATION_DURATION.likeIgnoreCase(likeExpression))
                     .or(Paper.PAPER.RESULT.likeIgnoreCase(likeExpression))
                     .or(Paper.PAPER.RESULT_EXPOSURE_RANGE.likeIgnoreCase(likeExpression))
                     .or(Paper.PAPER.RESULT_EFFECT_ESTIMATE.likeIgnoreCase(likeExpression))

--- a/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/paper/PaperFilterConditionMapperTest.kt
+++ b/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/paper/PaperFilterConditionMapperTest.kt
@@ -50,6 +50,19 @@ internal class PaperFilterConditionMapperTest : FilterConditionMapperTest<PaperR
     }
 
     @Test
+    fun creatingWhereCondition_withPopulationMask_searchesPopulationFields() {
+        val pattern = "m"
+        filter.populationMask = pattern
+        mapper.map(filter).toString() shouldBeEqualTo makeWhereClause(
+            pattern,
+            "population",
+            "population_place",
+            "population_participants",
+            "population_duration",
+        )
+    }
+
+    @Test
     fun creatingWhereCondition_withSearchMask_searchesRemainingTextFields() {
         val pattern = "foo"
         filter.searchMask = pattern
@@ -59,9 +72,6 @@ internal class PaperFilterConditionMapperTest : FilterConditionMapperTest<PaperR
             "location",
             "title",
             "goals",
-            "population",
-            "population_participants",
-            "population_duration",
             "result",
             "result_exposure_range",
             "result_effect_estimate",

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel.utf8.properties
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel.utf8.properties
@@ -1,7 +1,7 @@
 tab1.label=Goals, Population, and Methods
 tab2.label=Results and Comments
 tab3.label=Codes and new Studies
-tab4.label=New Field Entry
+tab4.label=Short Summary
 tab5.label=Original Abstract
 tab6.label=Attachments
 tab7.label=Newsletter

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage.html
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage.html
@@ -19,11 +19,15 @@
                         <div wicket:id="pubYearUntilLabel"></div>
                         <input wicket:id="pubYearUntil" class="form-control"/>
                     </div>
-                    <div class="col-xs-6 col-sm-3 col-md-2">
+                    <div class="col-xs-4 col-sm-2 col-md-2">
                         <div wicket:id="methodsSearchLabel"></div>
                         <input wicket:id="methodsSearch" class="form-control"/>
                     </div>
-                    <div class="col-xs-6 col-sm-3 col-md-2">
+                    <div class="col-xs-4 col-sm-2 col-md-2">
+                        <div wicket:id="populationSearchLabel"></div>
+                        <input wicket:id="populationSearch" class="form-control"/>
+                    </div>
+                    <div class="col-xs-4 col-sm-2 col-md-1">
                         <div wicket:id="authorsSearchLabel"></div>
                         <input wicket:id="authorsSearch" class="form-control"/>
                     </div>
@@ -31,7 +35,7 @@
                         <div wicket:id="fieldSearchLabel"></div>
                         <input wicket:id="fieldSearch" class="form-control"/>
                     </div>
-                    <div class="col-xs-7 col-sm-3 col-md-3 text-right" style="bottom: -20px;">
+                    <div class="col-xs-7 col-sm-3 col-md-2 text-right" style="bottom: -20px;">
                         <a wicket:id="newPaper">New Paper</a> <a wicket:id="showXmlPasteModalLink">PubMed XML</a>
                     </div>
                 </form>

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage.kt
@@ -103,6 +103,7 @@ class PaperListPage(parameters: PageParameters?) : BasePage<Void?>(parameters) {
         queueFieldAndLabel(TextField("number", PropertyModel.of<Any>(filter, PaperFilterFields.NUMBER.fieldName)))
         queueFieldAndLabel(TextField("authorsSearch", PropertyModel.of<Any>(filter, PaperFilterFields.AUTHOR_MASK.fieldName)))
         queueFieldAndLabel(TextField("methodsSearch", PropertyModel.of<Any>(filter, PaperFilterFields.METHODS_MASK.fieldName)))
+        queueFieldAndLabel(TextField("populationSearch", PropertyModel.of<Any>(filter, PaperFilterFields.POPULATION_MASK.fieldName)))
         queueFieldAndLabel(TextField("fieldSearch", PropertyModel.of<Any>(filter, PaperFilterFields.SEARCH_MASK.fieldName)))
         queueFieldAndLabel(TextField("pubYearFrom", PropertyModel.of<Any>(filter, PaperFilterFields.PUB_YEAR_FROM.fieldName)))
         queueFieldAndLabel(TextField("pubYearUntil", PropertyModel.of<Any>(filter, PaperFilterFields.PUB_YEAR_UNTIL.fieldName)))

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage.utf8.properties
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage.utf8.properties
@@ -1,5 +1,6 @@
 number.label=No.
 methodsSearch.label=Method search
+populationSearch.label=Population search
 authorsSearch.label=Authors search
 fieldSearch.label=Search in other fields
 pubYearFrom.label=Pub. Year (from)

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage_de.utf8.properties
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/list/PaperListPage_de.utf8.properties
@@ -1,5 +1,6 @@
 number.label=Nr.
 methodsSearch.label=Methoden Suche
+populationSearch.label=Kollektiv Suche
 authorsSearch.label=Autor(en) Suche
 fieldSearch.label=Suche in anderen Feldern
 pubYearFrom.label=Jahr (von)

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/common/PaperPanelTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/common/PaperPanelTest.kt
@@ -135,7 +135,7 @@ abstract class PaperPanelTest<T, P : PaperPanel<T>> : PanelTest<P>() where T : C
         assertTextAreaWithLabel("$bbb:goals", "g", "Goals")
         assertTextAreaWithLabel("$bbb:population", "p", "Population")
         assertTextAreaWithLabel("$bbb:methods", "m", "Methods")
-        assertTextAreaWithLabel("$bbb:populationPlace", "ppl", "Place/Country (study name)")
+        assertTextAreaWithLabel("$bbb:populationPlace", "ppl", "Place/Country")
         assertTextAreaWithLabel("$bbb:populationParticipants", "ppa", "Participants")
         assertTextAreaWithLabel("$bbb:populationDuration", "pd", "Study Duration")
         assertTextAreaWithLabel("$bbb:exposurePollutant", "ep", "Pollutant")
@@ -169,7 +169,7 @@ abstract class PaperPanelTest<T, P : PaperPanel<T>> : PanelTest<P>() where T : C
         tester.clickLink("panel:form:tabs:tabs-container:tabs:3:link")
         bbb = "$bb:tab4Form"
         tester.assertComponent(bbb, Form::class.java)
-        assertTextAreaWithLabel("$bbb:populationPlace", "ppl", "Place/Country (study name)")
+        assertTextAreaWithLabel("$bbb:populationPlace", "ppl", "Place/Country")
         assertTextAreaWithLabel("$bbb:populationParticipants", "ppa", "Participants")
         assertTextAreaWithLabel("$bbb:populationDuration", "pd", "Study Duration")
         assertTextAreaWithLabel("$bbb:exposurePollutant", "ep", "Pollutant")

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/common/PaperPanelTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/common/PaperPanelTest.kt
@@ -196,7 +196,7 @@ abstract class PaperPanelTest<T, P : PaperPanel<T>> : PanelTest<P>() where T : C
         tester.assertLabel(bb + "0:link:title", "Goals, Population, and Methods")
         tester.assertLabel(bb + "1:link:title", "Results and Comments")
         tester.assertLabel(bb + "2:link:title", "Codes and new Studies")
-        tester.assertLabel(bb + "3:link:title", "New Field Entry")
+        tester.assertLabel(bb + "3:link:title", "Short Summary")
         tester.assertLabel(bb + "4:link:title", "Original Abstract")
         tester.assertLabel(bb + "5:link:title", "Attachments")
         tester.assertLabel(bb + "6:link:title", "Newsletter")

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/jasper/summaryshort/PaperSummaryShortDataSourceTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/jasper/summaryshort/PaperSummaryShortDataSourceTest.kt
@@ -229,7 +229,7 @@ internal class PaperSummaryShortDataSourceTest : PaperDataSourceTest() {
         private const val METHOD_OUTCOME_LABEL = "Gesundheitliche Zielgrössen"
         private const val RESULT_MEASURED_OUTCOME_LABEL = "Gemessene Zielgrösse"
         private const val METHOD_STUDY_DESIGN_LABEL = "Studiendesign"
-        private const val POPULATION_PLACE_LABEL = "Ort/Land (Studie)"
+        private const val POPULATION_PLACE_LABEL = "Ort/Land"
         private const val POPULATION_PARTICIPANTS_LABEL = "Studienteilnehmer"
         private const val POPULATION_DURATION_LABEL = "Studiendauer"
         private const val EXPOSURE_POLLUTANT_LABEL = "Schadstoff"

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/list/PaperListPageTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/list/PaperListPageTest.kt
@@ -51,6 +51,7 @@ internal abstract class PaperListPageTest : BasePageTest<PaperListPage>() {
         assertLabeledTextField(b!!, "number")
         assertLabeledTextField(b, "authorsSearch")
         assertLabeledTextField(b, "methodsSearch")
+        assertLabeledTextField(b, "populationSearch")
         assertLabeledTextField(b, "fieldSearch")
         assertLabeledTextField(b, "pubYearFrom")
         assertLabeledTextField(b, "pubYearUntil")


### PR DESCRIPTION
Resolves #306

- Extends the search in search field `population` to also search in `place/country`, `population`, `duration`.
- Introduces a new filter field `population` that respects the same fields (removing them from the generic search field).