### PR TITLE
chore(deps): Bump spring-boot and related depenedencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -72,7 +72,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Added
 
 .Changed
-- Bumped spring-boot, spring-cloud, spring-cloud-starter
+- Bumped spring-boot, spring-cloud, spring-cloud-starter, jOOQ
 
 ////
 .Deprecated

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -70,9 +70,11 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 {url-cl}1.6.9$$...$$main[Full Changelog]
 
 .Added
-////
-.Changed
 
+.Changed
+- Bumped spring-boot, spring-cloud, spring-cloud-starter
+
+////
 .Deprecated
 
 .Removed

--- a/buildSrc/src/main/kotlin/Lib.kt
+++ b/buildSrc/src/main/kotlin/Lib.kt
@@ -23,7 +23,7 @@ object Lib {
     private const val univocityParsersVersion = "2.9.1"
 
     private const val krisVersion = "0.3.2"
-    const val jooqVersion = "3.14.15"
+    const val jooqVersion = "3.15.4"
     const val flywayVersion = "8.0.5"
 
     private const val kotlinLoggingVersion = "2.0.11"

--- a/buildSrc/src/main/kotlin/Lib.kt
+++ b/buildSrc/src/main/kotlin/Lib.kt
@@ -9,10 +9,10 @@ object Lib {
     //region:dependencyVersions
     private const val kotlinVersion = "1.6.0"
 
-    private const val springBootVersion = "2.5.7"
+    private const val springBootVersion = "2.6.0"
     private const val springBootAdminVersion = "2.5.4"
-    const val springCloudVersion = "2020.0.3"
-    private const val springCloudStarterVersion = "3.0.3"
+    const val springCloudVersion = "2021.0.0"
+    private const val springCloudStarterVersion = "3.1.0-RC1"
 
     private const val wicketSpringBootStarterVersion = "3.0.4"
     private const val wicketVersion = "9.6.0"

--- a/common/common-persistence-jooq-test/src/main/kotlin/ch/difty/scipamato/common/persistence/FilterConditionMapperTest.kt
+++ b/common/common-persistence-jooq-test/src/main/kotlin/ch/difty/scipamato/common/persistence/FilterConditionMapperTest.kt
@@ -3,11 +3,11 @@ package ch.difty.scipamato.common.persistence
 import ch.difty.scipamato.common.entity.filter.ScipamatoFilter
 import org.amshove.kluent.shouldBeEqualTo
 import org.jooq.Record
-import org.jooq.impl.TableImpl
+import org.jooq.Table
 import org.junit.jupiter.api.Test
 
 @Suppress("FunctionName", "kotlin:S100")
-abstract class FilterConditionMapperTest<R : Record, TI : TableImpl<R>, F : ScipamatoFilter> {
+abstract class FilterConditionMapperTest<R : Record, TI : Table<R>, F : ScipamatoFilter> {
 
     protected abstract val table: TI
 

--- a/common/common-persistence-jooq/src/main/kotlin/ch/difty/scipamato/common/persistence/JooqSortMapper.kt
+++ b/common/common-persistence-jooq/src/main/kotlin/ch/difty/scipamato/common/persistence/JooqSortMapper.kt
@@ -5,7 +5,7 @@ import ch.difty.scipamato.common.entity.ScipamatoEntity
 import ch.difty.scipamato.common.persistence.paging.Sort
 import org.jooq.Record
 import org.jooq.SortField
-import org.jooq.impl.TableImpl
+import org.jooq.Table
 
 /**
  * Implementations of this interface map sorting specifications into the jOOQ specific [SortField]s.
@@ -15,7 +15,7 @@ import org.jooq.impl.TableImpl
  * @param [T] the type of the table implementation of record [R]
  */
 @Deprecated("replace with JooqDbSortMapper")
-fun interface JooqSortMapper<R : Record, T : ScipamatoEntity, TI : TableImpl<R>> {
+fun interface JooqSortMapper<R : Record, T : ScipamatoEntity, TI : Table<R>> {
 
     /**
      * Maps spring data [sortSpecification] of [table] [TI] into the jOOQ specific [SortField]s.
@@ -30,7 +30,7 @@ fun interface JooqSortMapper<R : Record, T : ScipamatoEntity, TI : TableImpl<R>>
  * @param [T] the type of the entity, extending [DbEntity]
  * @param [T] the type of the table implementation of record [R]
  */
-fun interface JooqDbSortMapper<R : Record, T : DbEntity, TI : TableImpl<R>> {
+fun interface JooqDbSortMapper<R : Record, T : DbEntity, TI : Table<R>> {
 
     /**
      * Maps spring data [sortSpecification] of [table] [TI] into the jOOQ specific [SortField]s.

--- a/common/common-persistence-jooq/src/main/kotlin/ch/difty/scipamato/common/persistence/SortMapper.kt
+++ b/common/common-persistence-jooq/src/main/kotlin/ch/difty/scipamato/common/persistence/SortMapper.kt
@@ -5,8 +5,8 @@ import ch.difty.scipamato.common.entity.ScipamatoEntity
 import ch.difty.scipamato.common.persistence.paging.Sort
 import org.jooq.Record
 import org.jooq.SortField
+import org.jooq.Table
 import org.jooq.TableField
-import org.jooq.impl.TableImpl
 import org.springframework.dao.InvalidDataAccessApiUsageException
 import org.springframework.stereotype.Component
 import java.util.*
@@ -24,7 +24,7 @@ import java.util.*
  */
 @Component
 @Deprecated("use DbSortMapper instead")
-class SortMapper<R : Record, T : ScipamatoEntity, TI : TableImpl<R>> : JooqSortMapper<R, T, TI> {
+class SortMapper<R : Record, T : ScipamatoEntity, TI : Table<R>> : JooqSortMapper<R, T, TI> {
 
     override fun map(sortSpecification: Sort?, table: TI): Collection<SortField<T>> =
         sortSpecification?.map { (propName, sortDirection) ->
@@ -38,7 +38,7 @@ class SortMapper<R : Record, T : ScipamatoEntity, TI : TableImpl<R>> : JooqSortM
     }
 
     /**
-     * reflection based field extraction so we can stub it out in tests
+     * reflection based field extraction, so we can stub it out in tests
      */
     @Suppress("UNCHECKED_CAST")
     @Throws(NoSuchFieldException::class, IllegalAccessException::class)
@@ -50,7 +50,7 @@ class SortMapper<R : Record, T : ScipamatoEntity, TI : TableImpl<R>> : JooqSortM
 }
 
 @Component
-class DbSortMapper<R : Record, T : DbEntity, TI : TableImpl<R>> : JooqDbSortMapper<R, T, TI> {
+class DbSortMapper<R : Record, T : DbEntity, TI : Table<R>> : JooqDbSortMapper<R, T, TI> {
 
     override fun map(sortSpecification: Sort?, table: TI): Collection<SortField<T>> =
         sortSpecification?.map { (propName, sortDirection) ->
@@ -64,7 +64,7 @@ class DbSortMapper<R : Record, T : DbEntity, TI : TableImpl<R>> : JooqDbSortMapp
     }
 
     /**
-     * reflection based field extraction so we can stub it out in tests
+     * reflection based field extraction, so we can stub it out in tests
      */
     @Suppress("UNCHECKED_CAST")
     @Throws(NoSuchFieldException::class, IllegalAccessException::class)

--- a/common/common-persistence-jooq/src/test/kotlin/ch/difty/scipamato/common/persistence/SortMapperTest.kt
+++ b/common/common-persistence-jooq/src/test/kotlin/ch/difty/scipamato/common/persistence/SortMapperTest.kt
@@ -10,24 +10,25 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldContainSame
 import org.amshove.kluent.shouldThrow
 import org.amshove.kluent.withMessage
 import org.jooq.Record
 import org.jooq.SortField
+import org.jooq.Table
 import org.jooq.TableField
-import org.jooq.impl.TableImpl
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.dao.InvalidDataAccessApiUsageException
 
 internal class SortMapperTest {
 
-    private val mapperSpy = spyk<SortMapper<Record, ScipamatoEntity, TableImpl<Record>>>()
+    private val mapperSpy = spyk<SortMapper<Record, ScipamatoEntity, Table<Record>>>()
 
     private val sortSpecMock = mockk<Sort>()
-    private val tableMock = mockk<TableImpl<Record>>()
+    private val tableMock = mockk<Table<Record>>()
     private val tableFieldMock = mockk<TableField<Record, ScipamatoEntity>>()
     private val sortFieldMock = mockk<SortField<ScipamatoEntity>>()
 
@@ -41,6 +42,7 @@ internal class SortMapperTest {
     @Test
     fun mapping_withNullSortSpecification_returnsEmptyList() {
         mapperSpy.map(null, tableMock).shouldBeEmpty()
+        true shouldBe true
     }
 
     @Test

--- a/common/common-wicket/src/test/resources/application.yml
+++ b/common/common-wicket/src/test/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   main:
     banner-mode: "off"
+    allow-circular-references: true
 logging:
   level:
     root: WARN

--- a/core/core-persistence-jooq/src/integration-test/kotlin/ch/difty/scipamato/core/persistence/paper/searchorder/StringSearchTermEvaluatorIntegrationTest.kt
+++ b/core/core-persistence-jooq/src/integration-test/kotlin/ch/difty/scipamato/core/persistence/paper/searchorder/StringSearchTermEvaluatorIntegrationTest.kt
@@ -33,11 +33,7 @@ internal class StringSearchTermEvaluatorIntegrationTest : SearchTermEvaluatorInt
             tokenString = "(WORD foo)",
             condition = """fn ilike ('%' || replace(
                                        |  replace(
-                                       |    replace(
-                                       |      'foo',
-                                       |      '!',
-                                       |      '!!'
-                                       |    ),
+                                       |    replace('foo', '!', '!!'),
                                        |    '%',
                                        |    '!%'
                                        |  ),
@@ -53,11 +49,7 @@ internal class StringSearchTermEvaluatorIntegrationTest : SearchTermEvaluatorInt
                                       |  ''
                                       |) ilike ('%' || replace(
                                       |  replace(
-                                      |    replace(
-                                      |      'foo',
-                                      |      '!',
-                                      |      '!!'
-                                      |    ),
+                                      |    replace('foo', '!', '!!'),
                                       |    '%',
                                       |    '!%'
                                       |  ),

--- a/core/core-persistence-jooq/src/integration-test/kotlin/ch/difty/scipamato/core/persistence/paper/searchorder/StringSearchTermEvaluatorTest.kt
+++ b/core/core-persistence-jooq/src/integration-test/kotlin/ch/difty/scipamato/core/persistence/paper/searchorder/StringSearchTermEvaluatorTest.kt
@@ -194,11 +194,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ''
                |) ilike ('%' || replace(
                |  replace(
-               |    replace(
-               |      'foo',
-               |      '!',
-               |      '!!'
-               |    ),
+               |    replace('foo', '!', '!!'),
                |    '%',
                |    '!%'
                |  ),
@@ -213,11 +209,7 @@ internal class StringSearchTermEvaluatorTest {
         evaluator.evaluate(stMock).toString() shouldBeEqualTo
             """field_x ilike ('%' || replace(
                |  replace(
-               |    replace(
-               |      'foo',
-               |      '!',
-               |      '!!'
-               |    ),
+               |    replace('foo', '!', '!!'),
                |    '%',
                |    '!%'
                |  ),
@@ -791,11 +783,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -807,11 +795,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -823,11 +807,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -839,11 +819,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -855,11 +831,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -871,11 +843,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -887,11 +855,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -903,11 +867,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -924,11 +884,7 @@ internal class StringSearchTermEvaluatorTest {
             """(
                |  methods ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -937,11 +893,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or method_study_design ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -950,11 +902,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or population_place ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -963,11 +911,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or method_outcome ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -976,11 +920,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or exposure_pollutant ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -989,11 +929,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or exposure_assessment ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1002,11 +938,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or method_statistics ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1015,11 +947,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or method_confounders ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1054,11 +982,7 @@ internal class StringSearchTermEvaluatorTest {
                |  (
                |    methods ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1067,11 +991,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or method_study_design ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1080,11 +1000,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or population_place ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1093,11 +1009,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or method_outcome ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1106,11 +1018,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or exposure_pollutant ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1119,11 +1027,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or exposure_assessment ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1132,11 +1036,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or method_statistics ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1145,11 +1045,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or method_confounders ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1162,11 +1058,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1178,11 +1070,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1194,11 +1082,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1210,11 +1094,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1226,11 +1106,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1242,11 +1118,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1258,11 +1130,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1274,11 +1142,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1648,11 +1512,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1664,11 +1524,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1680,11 +1536,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1696,11 +1548,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1717,11 +1565,7 @@ internal class StringSearchTermEvaluatorTest {
             """(
                |  population ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1730,11 +1574,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or population_place ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1743,11 +1583,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or population_participants ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1756,11 +1592,7 @@ internal class StringSearchTermEvaluatorTest {
                |  ) || '%') escape '!'
                |  or population_duration ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'foo',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('foo', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1795,11 +1627,7 @@ internal class StringSearchTermEvaluatorTest {
                |  (
                |    population ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1808,11 +1636,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or population_place ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1821,11 +1645,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or population_participants ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1834,11 +1654,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ) || '%') escape '!'
                |    or population_duration ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -1851,11 +1667,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1867,11 +1679,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1883,11 +1691,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),
@@ -1899,11 +1703,7 @@ internal class StringSearchTermEvaluatorTest {
                |    ''
                |  ) ilike ('%' || replace(
                |    replace(
-               |      replace(
-               |        'bar',
-               |        '!',
-               |        '!!'
-               |      ),
+               |      replace('bar', '!', '!!'),
                |      '%',
                |      '!%'
                |    ),

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqEntityRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqEntityRepo.java
@@ -5,7 +5,6 @@ import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jooq.*;
-import org.jooq.impl.TableImpl;
 import org.slf4j.Logger;
 
 import ch.difty.scipamato.common.DateTimeService;
@@ -35,7 +34,7 @@ import ch.difty.scipamato.core.persistence.OptimisticLockingException.Type;
  * @author u.joss
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class JooqEntityRepo<R extends Record, T extends CoreEntity, ID, TI extends TableImpl<R>, M extends RecordMapper<R, T>, F extends ScipamatoFilter>
+public abstract class JooqEntityRepo<R extends Record, T extends CoreEntity, ID, TI extends Table<R>, M extends RecordMapper<R, T>, F extends ScipamatoFilter>
     extends JooqReadOnlyRepo<R, T, ID, TI, M, F> implements EntityRepository<T, ID, F> {
 
     private final InsertSetStepSetter<R, T> insertSetStepSetter;
@@ -105,8 +104,7 @@ public abstract class JooqEntityRepo<R extends Record, T extends CoreEntity, ID,
     public T add(@NotNull final T entity, @NotNull final String languageCode) {
         R saved = doSave(entity, languageCode);
         if (saved != null) {
-            getLogger().info("{} inserted 1 record: {} with id {}.", getActiveUser().getUserName(),
-                getTable().getName(), getIdFrom(saved));
+            getLogger().info("{} inserted 1 record: {} with id {}.", getActiveUser().getUserName(), getTable().getName(), getIdFrom(saved));
             T savedEntity = getMapper().map(saved);
             enrichAssociatedEntitiesOf(savedEntity, languageCode);
             return savedEntity;
@@ -155,8 +153,7 @@ public abstract class JooqEntityRepo<R extends Record, T extends CoreEntity, ID,
                 .and(getRecordVersion().eq(version))
                 .execute();
             if (deleteCount > 0) {
-                getLogger().info("{} deleted {} record: {} with id {}.", getActiveUser().getUserName(), deleteCount,
-                    getTable().getName(), id);
+                getLogger().info("{} deleted {} record: {} with id {}.", getActiveUser().getUserName(), deleteCount, getTable().getName(), id);
             } else {
                 throw new OptimisticLockingException(getTable().getName(), toBeDeleted.toString(), Type.DELETE);
             }
@@ -202,8 +199,7 @@ public abstract class JooqEntityRepo<R extends Record, T extends CoreEntity, ID,
             updateAssociatedEntities(entity, languageCode);
             T savedEntity = findById(id);
             enrichAssociatedEntitiesOf(savedEntity, languageCode);
-            getLogger().info("{} updated 1 record: {} with id {}.", getActiveUser().getUserName(), getTable().getName(),
-                id);
+            getLogger().info("{} updated 1 record: {} with id {}.", getActiveUser().getUserName(), getTable().getName(), id);
             return savedEntity;
         } else {
             throw new OptimisticLockingException(getTable().getName(), entity.toString(), Type.UPDATE);

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqReadOnlyRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqReadOnlyRepo.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jooq.*;
-import org.jooq.impl.TableImpl;
 
 import ch.difty.scipamato.common.DateTimeService;
 import ch.difty.scipamato.common.config.ApplicationProperties;
@@ -35,7 +34,7 @@ import ch.difty.scipamato.core.entity.CoreEntity;
  * @author u.joss
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class JooqReadOnlyRepo<R extends Record, T extends CoreEntity, ID, TI extends TableImpl<R>, M extends RecordMapper<R, T>, F extends ScipamatoFilter>
+public abstract class JooqReadOnlyRepo<R extends Record, T extends CoreEntity, ID, TI extends Table<R>, M extends RecordMapper<R, T>, F extends ScipamatoFilter>
     extends AbstractRepo implements ReadOnlyRepository<T, ID, F> {
 
     private final M                               mapper;
@@ -59,8 +58,7 @@ public abstract class JooqReadOnlyRepo<R extends Record, T extends CoreEntity, I
      * @param applicationProperties
      *     the object providing the application properties
      */
-    protected JooqReadOnlyRepo(@NotNull final DSLContext dsl, @NotNull final M mapper,
-        @NotNull final JooqSortMapper<R, T, TI> sortMapper,
+    protected JooqReadOnlyRepo(@NotNull final DSLContext dsl, @NotNull final M mapper, @NotNull final JooqSortMapper<R, T, TI> sortMapper,
         @NotNull GenericFilterConditionMapper<F> filterConditionMapper, @NotNull DateTimeService dateTimeService,
         @NotNull ApplicationProperties applicationProperties) {
         super(dsl, dateTimeService);
@@ -192,8 +190,7 @@ public abstract class JooqReadOnlyRepo<R extends Record, T extends CoreEntity, I
 
     @NotNull
     @Override
-    public List<T> findPageByFilter(@Nullable final F filter, @NotNull final PaginationContext pc,
-        @Nullable final String languageCode) {
+    public List<T> findPageByFilter(@Nullable final F filter, @NotNull final PaginationContext pc, @Nullable final String languageCode) {
         final Condition conditions = filterConditionMapper.map(filter);
         final Collection<SortField<T>> sortCriteria = getSortMapper().map(pc.getSort(), getTable());
         final List<T> entities = getDsl()

--- a/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/JooqEntityRepoTest.kt
+++ b/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/JooqEntityRepoTest.kt
@@ -21,12 +21,12 @@ import org.jooq.InsertSetMoreStep
 import org.jooq.InsertSetStep
 import org.jooq.Record
 import org.jooq.RecordMapper
+import org.jooq.Table
 import org.jooq.TableField
 import org.jooq.UpdateConditionStep
 import org.jooq.UpdateResultStep
 import org.jooq.UpdateSetFirstStep
 import org.jooq.UpdateSetMoreStep
-import org.jooq.impl.TableImpl
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -46,7 +46,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
  * pressure of sonarqube :-) )
  */
 @ExtendWith(SpringExtension::class)
-abstract class JooqEntityRepoTest<R : Record, T : IdScipamatoEntity<ID>, ID : Number, TI : TableImpl<R>,
+abstract class JooqEntityRepoTest<R : Record, T : IdScipamatoEntity<ID>, ID : Number, TI : Table<R>,
     M : RecordMapper<R, T>, F : ScipamatoFilter> : JooqReadOnlyRepoTest<R, T, ID, TI, M, F>() {
 
     protected val insertSetStepSetter = mockk<InsertSetStepSetter<R, T>>()

--- a/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/JooqReadOnlyRepoTest.kt
+++ b/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/JooqReadOnlyRepoTest.kt
@@ -25,8 +25,8 @@ import org.jooq.SelectSeekStepN
 import org.jooq.SelectSelectStep
 import org.jooq.SelectWhereStep
 import org.jooq.SortField
+import org.jooq.Table
 import org.jooq.TableField
-import org.jooq.impl.TableImpl
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,7 +35,7 @@ abstract class JooqReadOnlyRepoTest<
     R : Record,
     T : IdScipamatoEntity<ID>,
     ID : Number,
-    TI : TableImpl<R>,
+    TI : Table<R>,
     M : RecordMapper<R, T>,
     F : ScipamatoFilter> {
 

--- a/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/paper/slim/JooqPaperSlimBySearchOrderRepoTest.kt
+++ b/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/paper/slim/JooqPaperSlimBySearchOrderRepoTest.kt
@@ -109,11 +109,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                   |    publication_year between 2014 and 2015
                   |    and authors ilike ('%' || replace(
                   |      replace(
-                  |        replace(
-                  |          'turner',
-                  |          '!',
-                  |          '!!'
-                  |        ),
+                  |        replace('turner', '!', '!!'),
                   |        '%',
                   |        '!%'
                   |      ),
@@ -154,11 +150,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                   |    publication_year between 2014 and 2015
                   |    and authors ilike ('%' || replace(
                   |      replace(
-                  |        replace(
-                  |          'turner',
-                  |          '!',
-                  |          '!!'
-                  |        ),
+                  |        replace('turner', '!', '!!'),
                   |        '%',
                   |        '!%'
                   |      ),
@@ -218,11 +210,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                   |      publication_year between 2014 and 2015
                   |      and authors ilike ('%' || replace(
                   |        replace(
-                  |          replace(
-                  |            'turner',
-                  |            '!',
-                  |            '!!'
-                  |          ),
+                  |          replace('turner', '!', '!!'),
                   |          '%',
                   |          '!%'
                   |        ),
@@ -279,11 +267,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                   |      publication_year between 2014 and 2015
                   |      and authors ilike ('%' || replace(
                   |        replace(
-                  |          replace(
-                  |            'turner',
-                  |            '!',
-                  |            '!!'
-                  |          ),
+                  |          replace('turner', '!', '!!'),
                   |          '%',
                   |          '!%'
                   |        ),
@@ -355,11 +339,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                  |    and "public"."paper_newsletter"."newsletter_topic_id" = 1
                  |    and "paper_newsletter"."headline" ilike ('%' || replace(
                  |      replace(
-                 |        replace(
-                 |          'hl',
-                 |          '!',
-                 |          '!!'
-                 |        ),
+                 |        replace('hl', '!', '!!'),
                  |        '%',
                  |        '!%'
                  |      ),
@@ -411,11 +391,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                   |    "public"."paper_newsletter"."paper_id" = "public"."paper"."id"
                   |    and "paper_newsletter"."headline" ilike ('%' || replace(
                   |      replace(
-                  |        replace(
-                  |          'hl',
-                  |          '!',
-                  |          '!!'
-                  |        ),
+                  |        replace('hl', '!', '!!'),
                   |        '%',
                   |        '!%'
                   |      ),
@@ -445,11 +421,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                   |    "public"."paper_newsletter"."paper_id" = "public"."paper"."id"
                   |    and "newsletter"."issue" ilike ('%' || replace(
                   |      replace(
-                  |        replace(
-                  |          'i',
-                  |          '!',
-                  |          '!!'
-                  |        ),
+                  |        replace('i', '!', '!!'),
                   |        '%',
                   |        '!%'
                   |      ),
@@ -559,11 +531,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                |      ''
                |    ) ilike ('%' || replace(
                |      replace(
-               |        replace(
-               |          'foo',
-               |          '!',
-               |          '!!'
-               |        ),
+               |        replace('foo', '!', '!!'),
                |        '%',
                |        '!%'
                |      ),
@@ -597,11 +565,7 @@ internal class JooqPaperSlimBySearchOrderRepoTest {
                   |      "public"."paper_newsletter"."paper_id" = "public"."paper"."id"
                   |      and "paper_newsletter"."headline" ilike ('%' || replace(
                   |        replace(
-                  |          replace(
-                  |            'hl',
-                  |            '!',
-                  |            '!!'
-                  |          ),
+                  |          replace('hl', '!', '!!'),
                   |          '%',
                   |          '!%'
                   |        ),

--- a/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/search/SearchOrderFilterConditionMapperTest.kt
+++ b/core/core-persistence-jooq/src/test/kotlin/ch/difty/scipamato/core/persistence/search/SearchOrderFilterConditionMapperTest.kt
@@ -23,11 +23,7 @@ internal class SearchOrderFilterConditionMapperTest :
         mapper.map(filter).toString() shouldBeEqualTo
             """"public"."search_order"."name" ilike ('%' || replace(
                 |  replace(
-                |    replace(
-                |      'fOo',
-                |      '!',
-                |      '!!'
-                |    ),
+                |    replace('fOo', '!', '!!'),
                 |    '%',
                 |    '!%'
                 |  ),

--- a/core/core-web/src/intTestDisabled/resources/application.yml
+++ b/core/core-web/src/intTestDisabled/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   main:
     allow-bean-definition-overriding: true
+    allow-circular-references: true
     banner-mode: "off"
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration

--- a/core/core-web/src/main/resources/application.properties
+++ b/core/core-web/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.main.allow-bean-definition-overriding=true
+spring.main.allow-circular-references=true
 
 #
 # Application specific settings

--- a/core/core-web/src/test/resources/application.properties
+++ b/core/core-web/src/test/resources/application.properties
@@ -1,4 +1,5 @@
 spring.main.allow-bean-definition-overriding=true
+spring.main.allow-circular-references=true
 spring.main.banner-mode=off
 spring.batch.job.enabled=false
 spring.flyway.enabled=false

--- a/public/public-web/src/integration-test/resources/application.properties
+++ b/public/public-web/src/integration-test/resources/application.properties
@@ -51,3 +51,5 @@ spring.datasource.hikari.max-lifetime=100000
 spring.datasource.hikari.pool-name=SciPaMaTo-Public-HikariCP
 spring.datasource.hikari.minimum-idle=2
 spring.datasource.hikari.maximum-pool-size=5
+
+spring.main.allow-circular-references: true

--- a/public/public-web/src/main/resources/application.properties
+++ b/public/public-web/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.main.allow-circular-references=true
+
 #
 # Application specific settings
 #

--- a/public/public-web/src/test/resources/application.yml
+++ b/public/public-web/src/test/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     exclude: org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
   main:
     allow-bean-definition-overriding: true
+    allow-circular-references: true
     banner-mode: "off"
   flyway:
     enabled: false


### PR DESCRIPTION
Bumps:

* spring-boot from 2.5.7 to 2.6.0
* spring cloud from 2020.0.3 to 2021.0.0
* spring-cloud-starter from 3.0.3 to 3.1.0-RC1
* jOOQ from 3.14.15 to 3.15.4

Aligns the code with some changes in jOOQ between 3.14 and 3.15. Having to change this is a smell of mostly some of the tests in scipamato. They are too tightly coupled to the implementation of the third-party library and testing that logic should actually be moved to integration tests.