### PR TITLE
fix(sync): [#344] Async call to spring batch data synchronization core -> public

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -81,9 +81,12 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Deprecated
 
 .Removed
+////
 
 .Fixed
+- {url-issues}344[#344] Handle spring batch data synchronization from core to public asynchronously
 
+////
 .Security
 
 ////

--- a/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/launcher/SyncJobLauncher.kt
+++ b/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/launcher/SyncJobLauncher.kt
@@ -4,8 +4,7 @@ package ch.difty.scipamato.core.sync.launcher
  * Launcher for spring-batch data synchronization from scipamato-core to scipamato-public.
  */
 fun interface SyncJobLauncher {
-    /**
-     * Launch the synchronization and return [SyncJobResult]
-     */
-    fun launch(): SyncJobResult
+
+    /** Launch the synchronization */
+    fun launch(setSuccess: (String) -> Unit, setFailure: (String) -> Unit, setWarning: (String) -> Unit, setDone: () -> Unit)
 }

--- a/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/launcher/SyncJobResult.kt
+++ b/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/launcher/SyncJobResult.kt
@@ -1,6 +1,8 @@
 package ch.difty.scipamato.core.sync.launcher
 
-import java.util.ArrayList
+import ch.difty.scipamato.common.persistence.paging.Sort
+import java.io.Serializable
+import kotlin.math.min
 
 /**
  * The [SyncJobResult] collects log messages for one or more job steps
@@ -10,6 +12,8 @@ import java.util.ArrayList
 class SyncJobResult {
     private val logMessages: MutableList<LogMessage> = ArrayList()
     private var result = JobResult.UNKNOWN
+    private var running = false
+    val isRunning get() = running
 
     val isSuccessful: Boolean
         get() = result == JobResult.SUCCESS
@@ -20,18 +24,45 @@ class SyncJobResult {
     val messages: List<LogMessage>
         get() = ArrayList(logMessages)
 
+    fun messageCount() = messages.size.toLong()
+
     fun setSuccess(msg: String) {
+        running = true
         if (result != JobResult.FAILURE) result = JobResult.SUCCESS
         logMessages.add(LogMessage(msg, MessageLevel.INFO))
     }
 
     fun setFailure(msg: String) {
+        running = true
         result = JobResult.FAILURE
         logMessages.add(LogMessage(msg, MessageLevel.ERROR))
     }
 
     fun setWarning(msg: String) {
+        running = true
         logMessages.add(LogMessage(msg, MessageLevel.WARNING))
+    }
+
+    fun setDone() {
+        running = false
+    }
+
+    fun getPagedResultMessages(first: Int, count: Int, sortProp: String, dir: Sort.Direction): Iterator<LogMessage> {
+        fun <T, R : Comparable<R>> List<T>.sortMethod(selector: (T) -> R?): List<T> =
+            if (dir == Sort.Direction.ASC) this.sortedBy(selector)
+            else sortedByDescending(selector)
+
+        val sorted = when (sortProp) {
+            "messageLevel" -> messages.sortMethod { it.messageLevel }
+            else -> messages.sortMethod { it.message }
+        }
+        return sorted.subList(first, min(first + count, messages.size)).iterator()
+    }
+
+    fun clear() {
+        logMessages.clear()
+        result = JobResult.UNKNOWN
+        setDone()
     }
 
     private enum class JobResult {
@@ -44,6 +75,10 @@ class SyncJobResult {
 
     data class LogMessage(
         val message: String? = null,
-        val messageLevel: MessageLevel? = null,
-    )
+        val messageLevel: MessageLevel = MessageLevel.INFO,
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 }

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/ScipamatoCoreApplication.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/ScipamatoCoreApplication.kt
@@ -1,6 +1,9 @@
 package ch.difty.scipamato.core
 
+import ch.difty.scipamato.common.logger
 import ch.difty.scipamato.common.web.AbstractPage
+import ch.difty.scipamato.core.web.sync.ISyncTask
+import ch.difty.scipamato.core.web.sync.TasksRunnable
 import com.giffing.wicket.spring.boot.starter.app.WicketBootSecuredWebApplication
 import org.apache.wicket.Session
 import org.apache.wicket.markup.head.filter.JavaScriptFilteredIntoFooterHeaderResponse
@@ -13,12 +16,19 @@ import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.ComponentScan
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+private val log = logger()
 
 @SpringBootApplication(exclude = [DataSourceAutoConfiguration::class])
 @EnableFeignClients
 @EnableCaching
 @ComponentScan(basePackages = ["ch.difty.scipamato"])
 open class ScipamatoCoreApplication : WicketBootSecuredWebApplication() {
+
+    private val executorService = Executors.newSingleThreadExecutor()
+
     override fun init() {
         // TODO consider making it CSP compliant
         cspSettings.blocking().disabled()
@@ -37,7 +47,30 @@ open class ScipamatoCoreApplication : WicketBootSecuredWebApplication() {
     }
 
     override fun newSession(request: Request, response: Response): Session = ScipamatoSession(request)
+
+    override fun onDestroy() {
+        executorService.shutdown()
+        try {
+            if (!executorService.awaitTermination(60, TimeUnit.SECONDS))
+                executorService.shutdownNow()
+        } catch (e: InterruptedException) {
+            log.error("Unable to shutdown executor service", e)
+        }
+        super.onDestroy()
+    }
+
+    @Synchronized
+    open fun launchSyncTask(task: ISyncTask) {
+        val sjr = ScipamatoSession.get().syncJobResult
+        sjr.clear()
+        executorService.execute(TasksRunnable(task, sjr::setSuccess, sjr::setFailure, sjr::setWarning, sjr::setDone))
+    }
+
+    companion object {
+        fun getApplication() = get() as ScipamatoCoreApplication
+    }
 }
+
 
 fun main(args: Array<String>) {
     runApplication<ScipamatoCoreApplication>(*args)

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/ScipamatoSession.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/ScipamatoSession.kt
@@ -2,6 +2,7 @@ package ch.difty.scipamato.core
 
 import ch.difty.scipamato.common.navigator.ItemNavigator
 import ch.difty.scipamato.common.navigator.LongNavigator
+import ch.difty.scipamato.core.sync.launcher.SyncJobResult
 import com.giffing.wicket.spring.boot.starter.configuration.extensions.external.spring.security.SecureWebSession
 import org.apache.wicket.Session
 import org.apache.wicket.request.Request
@@ -13,9 +14,14 @@ import org.apache.wicket.request.Request
  * latest search result. Both keeps track of the id of the currently
  * viewed/edited paper ('focus') and/or move the focus to the previous/next
  * paper in the list of managed ids.
+ *
+ * Holds an instance of the [SyncJobResult] capturing the state of the
+ * Spring batch job that synchronizes Core data to the public database.
  */
 class ScipamatoSession(request: Request) : SecureWebSession(request) {
     val paperIdManager: ItemNavigator<Long> = LongNavigator()
+
+    val syncJobResult: SyncJobResult = SyncJobResult()
 
     companion object {
         private const val serialVersionUID = 1L

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/BatchJobLaunchedEvent.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/BatchJobLaunchedEvent.kt
@@ -1,0 +1,10 @@
+package ch.difty.scipamato.core.web.sync
+
+import org.apache.wicket.ajax.AjaxRequestTarget
+import java.io.Serializable
+
+class BatchJobLaunchedEvent(var target: AjaxRequestTarget) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/RefDataSyncPage.html
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/RefDataSyncPage.html
@@ -1,10 +1,20 @@
 <!DOCTYPE html>
 <html xmlns:wicket="https://wicket.apache.org">
 <body>
+    <head>
+        <link rel="stylesheet" href="style.css" type="text/css" media="screen" title="Stylesheet"/>
+    </head>
     <wicket:extend>
         <div class="container-fluid">
             <form wicket:id="synchForm" role="form">
-                <button wicket:id="synchronize"></button>
+                <div class="row">
+                    <div class="col-sm-2 col-md-2">
+                        <button wicket:id="synchronize"></button>
+                    </div>
+                    <div class="col-sm-10 col-md-10">
+                        <div wicket:id="syncResults"/>
+                    </div>
+                </div>
             </form>
         </div>
     </wicket:extend>

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/RefDataSyncPage.utf8.properties
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/RefDataSyncPage.utf8.properties
@@ -1,4 +1,6 @@
 button.synchronize.label=synchronize
+button.synchronize-wip.label=synchronizing...
 
+feedback.msg.started=Data synchronization started...
 feedback.msg.success=Data was successfully exported to the public database.
 feedback.msg.failed=Unexpected error occurred while exporting the data to the public database.

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/RefDataSyncPage_de.utf8.properties
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/RefDataSyncPage_de.utf8.properties
@@ -1,4 +1,6 @@
 button.synchronize.label=abgleichen
+button.synchronize-wip.label=am abgleichen...
 
+feedback.msg.started=Daten-Ssynchronisierung wurde gestartet...
 feedback.msg.success=Die Daten wurden erfolgreich in die öffentliche Datenbank exportiert.
 feedback.msg.failed=Beim Exportieren der Daten in die öffentliche Datenbank trat ein unerwarteter Fehler auf.

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncBatchTask.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncBatchTask.kt
@@ -1,0 +1,58 @@
+package ch.difty.scipamato.core.web.sync
+
+import ch.difty.scipamato.core.sync.launcher.SyncJobLauncher
+import org.apache.wicket.Application
+import org.apache.wicket.Session
+import org.apache.wicket.ThreadContext
+import org.apache.wicket.injection.Injector
+import java.io.Serializable
+
+interface ISyncTask : Serializable {
+    fun launchJob(
+        setSuccess: (String) -> Unit,
+        setFailure: (String) -> Unit,
+        setWarning: (String) -> Unit,
+        setDone: () -> Unit,
+    )
+}
+
+class SyncBatchTask(private val jobLauncher: SyncJobLauncher) : ISyncTask {
+
+    init {
+        Injector.get().inject(this)
+    }
+
+    override fun launchJob(
+        setSuccess: (String) -> Unit,
+        setFailure: (String) -> Unit,
+        setWarning: (String) -> Unit,
+        setDone: () -> Unit,
+    ) {
+        jobLauncher.launch(setSuccess, setFailure, setWarning, setDone)
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+class TasksRunnable(
+    private val task: ISyncTask,
+    private val setSuccess: (String) -> Unit,
+    private val setFailure: (String) -> Unit,
+    private val setWarning: (String) -> Unit,
+    private val setDone: () -> Unit,
+) : Runnable {
+    private val application: Application = Application.get()
+    private val session: Session? = if (Session.exists()) Session.get() else null
+
+    override fun run() {
+        try {
+            ThreadContext.setApplication(application)
+            ThreadContext.setSession(session)
+            task.launchJob(setSuccess, setFailure, setWarning, setDone)
+        } finally {
+            ThreadContext.detach()
+        }
+    }
+}

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultDataProvider.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultDataProvider.kt
@@ -1,0 +1,29 @@
+package ch.difty.scipamato.core.web.sync
+
+import ch.difty.scipamato.common.persistence.paging.Sort
+import ch.difty.scipamato.core.ScipamatoSession
+import ch.difty.scipamato.core.sync.launcher.SyncJobResult
+import org.apache.wicket.extensions.markup.html.repeater.util.SortParam
+import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider
+import org.apache.wicket.model.IModel
+import org.apache.wicket.model.Model
+
+class SyncResultDataProvider : SortableDataProvider<SyncJobResult.LogMessage, String>() {
+
+    private val syncJobResult get() = ScipamatoSession.get().syncJobResult
+
+    override fun iterator(first: Long, count: Long): Iterator<SyncJobResult.LogMessage> {
+        val s : SortParam<String>? = sort
+        val dir = if (s == null || s.isAscending) Sort.Direction.ASC else Sort.Direction.DESC
+        val sortProp = s?.property ?: "message"
+        return syncJobResult.getPagedResultMessages(first.toInt(), count.toInt(), sortProp, dir)
+    }
+
+    override fun size() = syncJobResult.messageCount()
+
+    override fun model(logMessage: SyncJobResult.LogMessage): IModel<SyncJobResult.LogMessage> = Model.of(logMessage)
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel.html
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel.html
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns:wicket="https://wicket.apache.org">
+<wicket:panel>
+    <table wicket:id="taskMessages" class="dataView"></table>
+</wicket:panel>
+</html>

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel.kt
@@ -1,0 +1,49 @@
+package ch.difty.scipamato.core.web.sync
+
+import ch.difty.scipamato.core.sync.launcher.SyncJobResult
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.table.BootstrapDefaultDataTable
+import org.apache.wicket.ajax.AjaxSelfUpdatingTimerBehavior
+import org.apache.wicket.event.IEvent
+import org.apache.wicket.extensions.markup.html.repeater.data.table.PropertyColumn
+import org.apache.wicket.markup.html.panel.Panel
+import org.apache.wicket.model.StringResourceModel
+import java.time.Duration
+
+@Suppress("serial")
+class SyncResultListPanel(id: String) : Panel(id) {
+
+    override fun onInitialize() {
+        super.onInitialize()
+        outputMarkupId = true
+        add(AjaxSelfUpdatingTimerBehavior(Duration.ofSeconds(5)))
+        makeAndQueueTable("taskMessages")
+    }
+
+    private fun makeAndQueueTable(id: String) {
+        buildList {
+            add(makePropertyColumn("messageLevel"))
+            add(makePropertyColumn("message"))
+        }.run {
+            queue(BootstrapDefaultDataTable(id, this, SyncResultDataProvider(), 20)).apply { outputMarkupId = true }
+        }
+    }
+
+    override fun onEvent(event: IEvent<*>) {
+        (event.payload as? BatchJobLaunchedEvent)?.let { jobLaunchedEvent ->
+            this@SyncResultListPanel.add(AjaxSelfUpdatingTimerBehavior(Duration.ofSeconds(5)))
+            jobLaunchedEvent.target.add(this@SyncResultListPanel)
+        }
+    }
+
+    private fun makePropertyColumn(propExpression: String) = PropertyColumn<SyncJobResult.LogMessage, String>(
+        StringResourceModel("${COLUMN_HEADER}$propExpression", this@SyncResultListPanel, null),
+        propExpression,
+        propExpression
+    )
+
+
+    companion object {
+        private const val serialVersionUID = 1L
+        private const val COLUMN_HEADER = "column.header."
+    }
+}

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel.utf8.properties
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel.utf8.properties
@@ -1,0 +1,2 @@
+column.header.messageLevel=Level
+column.header.message=Message

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel_de.utf8.properties
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/sync/SyncResultListPanel_de.utf8.properties
@@ -1,0 +1,2 @@
+column.header.messageLevel=Stufe
+column.header.message=Meldung

--- a/core/core-web/src/main/webapp/style.css
+++ b/core/core-web/src/main/webapp/style.css
@@ -1,0 +1,3 @@
+table.taskMessages {
+    width: 100%;
+}

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/RefDataSyncPageTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/RefDataSyncPageTest.kt
@@ -1,21 +1,15 @@
 package ch.difty.scipamato.core.web.sync
 
 import ch.difty.scipamato.core.sync.launcher.SyncJobLauncher
-import ch.difty.scipamato.core.sync.launcher.SyncJobResult
 import ch.difty.scipamato.core.web.common.BasePageTest
 import com.ninjasquad.springmockk.MockkBean
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.ladda.LaddaAjaxButton
+import de.agilecoders.wicket.core.markup.html.bootstrap.button.BootstrapAjaxButton
 import io.mockk.confirmVerified
-import io.mockk.every
-import io.mockk.verify
 import org.apache.wicket.markup.html.form.Form
 import org.apache.wicket.request.mapper.parameter.PageParameters
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
 
 internal class RefDataSyncPageTest : BasePageTest<RefDataSyncPage>() {
-
-    private val result = SyncJobResult()
 
     @MockkBean
     private lateinit var jobLauncherMock: SyncJobLauncher
@@ -32,39 +26,7 @@ internal class RefDataSyncPageTest : BasePageTest<RefDataSyncPage>() {
 
     override fun assertSpecificComponents() {
         tester.assertComponent("synchForm", Form::class.java)
-        tester.assertComponent("synchForm:synchronize", LaddaAjaxButton::class.java)
-    }
-
-    @Test
-    fun submitting_triggersSynchronize_withSuccess() {
-        result.setSuccess("yep")
-        assertAjaxEvent("yep", "Data was successfully exported to the public database.", result)
-        tester.assertInfoMessages("Data was successfully exported to the public database.", "yep")
-        tester.assertNoErrorMessage()
-    }
-
-    @Test
-    fun submitting_triggersSynchronize_withFailure() {
-        result.setFailure("nope")
-        assertAjaxEvent("nope", "Unexpected error occurred while exporting the data to the public database.", result)
-    }
-
-    @Test
-    fun submitting_triggersSynchronize_withWarn() {
-        result.setSuccess("yep")
-        result.setWarning("hmmm")
-        assertAjaxEvent("yep", "Data was successfully exported to the public database.", result)
-        tester.assertInfoMessages("Data was successfully exported to the public database.", "yep")
-        tester.assertNoErrorMessage()
-    }
-
-    private fun assertAjaxEvent(msg: String, expectedLabelText: String, result: SyncJobResult) {
-        every { jobLauncherMock.launch() } returns result
-        tester.startPage(makePage())
-        tester.executeAjaxEvent("synchForm:synchronize", "click")
-        tester.assertComponentOnAjaxResponse("feedback")
-        tester.assertLabel("feedback:feedbackul:messages:0:message:message", expectedLabelText)
-        tester.assertLabel("feedback:feedbackul:messages:1:message:message", msg)
-        verify { jobLauncherMock.launch() }
+        tester.assertComponent("synchForm:synchronize", BootstrapAjaxButton::class.java)
+        tester.assertComponent("synchForm:syncResults", SyncResultListPanel::class.java)
     }
 }

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/SyncBatchTaskTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/SyncBatchTaskTest.kt
@@ -1,0 +1,45 @@
+package ch.difty.scipamato.core.web.sync
+
+import ch.difty.scipamato.core.sync.launcher.SyncJobLauncher
+import ch.difty.scipamato.core.web.AbstractWicketTest
+import org.amshove.kluent.shouldBe
+import org.apache.wicket.util.tester.WicketTester
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SyncBatchTaskTest : AbstractWicketTest() {
+
+    private lateinit var setSuccess: (String) -> Unit
+    private lateinit var setFailure: (String) -> Unit
+    private lateinit var setWarning: (String) -> Unit
+    private lateinit var setDone: () -> Unit
+
+    private val jobLauncher = SyncJobLauncher { ss, sf, sw, sd ->
+        setSuccess = ss
+        setFailure = sf
+        setWarning = sw
+        setDone = sd
+    }
+
+    @BeforeEach
+    fun setUp() {
+        WicketTester(application)
+    }
+
+    @Test
+    @Suppress("Unused_Expression")
+    fun syncBatchTask_shouldPassLambdasToLauncher() {
+        val ss: (String) -> Unit = { s -> s + s }
+        val sf: (String) -> Unit = { s -> s + s + s }
+        val sw: (String) -> Unit = { s -> s }
+        val d: () -> Unit = { true }
+
+        val sbt = SyncBatchTask(jobLauncher)
+        sbt.launchJob(ss, sf, sw, d)
+
+        setSuccess shouldBe ss
+        setFailure shouldBe sf
+        setWarning shouldBe sw
+        setDone shouldBe d
+    }
+}

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/SyncResultDataProviderTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/SyncResultDataProviderTest.kt
@@ -1,0 +1,54 @@
+package ch.difty.scipamato.core.web.sync
+
+import ch.difty.scipamato.core.ScipamatoSession
+import ch.difty.scipamato.core.sync.launcher.SyncJobResult
+import ch.difty.scipamato.core.web.AbstractWicketTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContainSame
+import org.apache.wicket.util.tester.WicketTester
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SyncResultDataProviderTest : AbstractWicketTest() {
+
+    private lateinit var provider: SyncResultDataProvider
+
+    @BeforeEach
+    fun setUp() {
+        WicketTester(application)
+        provider = SyncResultDataProvider()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ScipamatoSession.get().syncJobResult.clear()
+    }
+
+    @Test
+    fun gettingModel_wrapsLogMessage() {
+        val logMessage = SyncJobResult.LogMessage("msg", SyncJobResult.MessageLevel.WARNING)
+        val model = provider.model(logMessage)
+        model.getObject() shouldBeEqualTo logMessage
+    }
+
+    @Test
+    fun iniatesWithSize0() {
+        provider.size() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun withSyncJobResultsAdded_reflectsSize() {
+        ScipamatoSession.get().syncJobResult.setSuccess("Foo")
+        ScipamatoSession.get().syncJobResult.setFailure("Bar")
+        provider.size() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun x() {
+        ScipamatoSession.get().syncJobResult.setSuccess("Foo")
+        ScipamatoSession.get().syncJobResult.setFailure("Bar")
+        provider.iterator(0, 2).asSequence().map { it.message }.toList().shouldContainSame(listOf("Foo", "Bar"))
+    }
+
+}

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/SyncResultListPanelTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/sync/SyncResultListPanelTest.kt
@@ -1,0 +1,38 @@
+package ch.difty.scipamato.core.web.sync
+
+import ch.difty.scipamato.core.ScipamatoSession
+import ch.difty.scipamato.core.web.common.PanelTest
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.table.BootstrapDefaultDataTable
+import org.apache.wicket.markup.html.panel.Panel
+import org.junit.jupiter.api.AfterEach
+
+class SyncResultListPanelTest : PanelTest<SyncResultListPanel>() {
+
+    override fun setUpHook() {
+        ScipamatoSession.get().syncJobResult.setWarning("unsynced foo")
+        ScipamatoSession.get().syncJobResult.setSuccess("successful bar")
+        ScipamatoSession.get().syncJobResult.setFailure("failed baz")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ScipamatoSession.get().clear()
+    }
+
+    override fun makePanel(): SyncResultListPanel = SyncResultListPanel(PANEL_ID)
+
+    override fun assertSpecificComponents() {
+        val b = PANEL_ID
+        tester.assertComponent(b, Panel::class.java)
+        val bb = "$b:taskMessages"
+        tester.assertComponent(bb, BootstrapDefaultDataTable::class.java)
+        assertTableRow("$bb:body:rows:1:cells", "ERROR", "failed baz")
+        assertTableRow("$bb:body:rows:2:cells", "INFO", "successful bar")
+        assertTableRow("$bb:body:rows:3:cells", "WARNING", "unsynced foo")
+    }
+
+    private fun assertTableRow(bb: String, level: String, msg: String) {
+        tester.assertLabel("$bb:1:cell", level)
+        tester.assertLabel("$bb:2:cell", msg)
+    }
+}


### PR DESCRIPTION
resolves #344

Instead of handling the entire long-running spring-batch process in the AjaxRequest, the current implementation launches an async task for the spring batch job and let's the job put status messages into the session.The table displaying the step results queries the session for the incoming messages.

This hopefully solves the problem at the production instance of SciPaMaTo where the batch job starts running for too long. Something seems to kill the running request before the sync job results can be displayed to the user. So while the job still ran - and actually finished successfully - the results were not displayed and the user didn't know about the state of the job.

Inspired by [antilla-bits/bgprocess](https://github.com/reiern70/antilia-bits/tree/master/bgprocess) - thanks to @reiern70