### PR TITLE
refactor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ buildscript {
     }
 }
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("jvm") version libs.versions.kotlin.get()
     kotlin("plugin.spring") version libs.versions.kotlin.get() apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.unbrokendome.gradle.plugins.testsets.TestSetsPlugin
 
 buildscript {
     repositories {
@@ -29,7 +28,6 @@ plugins {
     alias(libs.plugins.lombok)
     idea
     jacoco
-    alias(libs.plugins.testSets)
     alias(libs.plugins.detekt)
     alias(libs.plugins.sonarqube)
     alias(libs.plugins.reckon)
@@ -95,17 +93,7 @@ subprojects {
     apply<ScipamatoJacocoPlugin>()
     apply<JavaPlugin>()
     apply<IdeaPlugin>()
-    apply<TestSetsPlugin>()
     apply<JacocoPlugin>()
-
-    testSets {
-        register("integrationTest") {
-            dirName = "integration-test"
-        }
-        register("adhocTest") {
-            dirName = "adhoc-test"
-        }
-    }
 
     // Breaks running the project from the IntelliJ Run Dashboard - disabling for now
     // idea {
@@ -193,13 +181,6 @@ subprojects {
         }
         withType<BootJar> {
             enabled = false
-        }
-        val integrationTest by existing {
-            description = "Runs the integration tests."
-            dependsOn(test)
-        }
-        named("check") {
-            dependsOn(integrationTest)
         }
 
         register("version") {

--- a/core/core-persistence-jooq/build.gradle.kts
+++ b/core/core-persistence-jooq/build.gradle.kts
@@ -5,6 +5,7 @@ import ch.ayedo.jooqmodelator.gradle.JooqModelatorTask
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.jooqModelator)
+    id("scipamato-integration-test")
 }
 
 description = "SciPaMaTo-Core :: Persistence jOOQ Project"
@@ -16,6 +17,18 @@ val generatedSourcesPath = "build/generated-src/jooq"
 val jooqConfigFile = "$buildDir/jooqConfig.xml"
 val dockerDbPort = 15432
 val props = file("src/integration-test/resources/application.properties").asProperties()
+
+testing {
+    suites {
+        val integrationTest by existing {
+            dependencies {
+                implementation(libs.bundles.dbTest)
+                runtimeOnly(libs.postgresql)
+                annotationProcessor(libs.lombok)
+            }
+        }
+    }
+}
 
 jooqModelator {
     jooqVersion = libs.versions.jooq.get()
@@ -56,10 +69,6 @@ dependencies {
 
     testImplementation(libs.lombok)
     testAnnotationProcessor(libs.lombok)
-
-//    integrationTestImplementation(libs.bundles.dbTest)
-//    integrationTestRuntimeOnly(libs.postgresql)
-//    integrationTestAnnotationProcessor(libs.lombok)
 }
 
 sourceSets {

--- a/core/core-persistence-jooq/build.gradle.kts
+++ b/core/core-persistence-jooq/build.gradle.kts
@@ -57,9 +57,9 @@ dependencies {
     testImplementation(libs.lombok)
     testAnnotationProcessor(libs.lombok)
 
-    integrationTestImplementation(libs.bundles.dbTest)
-    integrationTestRuntimeOnly(libs.postgresql)
-    integrationTestAnnotationProcessor(libs.lombok)
+//    integrationTestImplementation(libs.bundles.dbTest)
+//    integrationTestRuntimeOnly(libs.postgresql)
+//    integrationTestAnnotationProcessor(libs.lombok)
 }
 
 sourceSets {

--- a/core/core-persistence-jooq/build.gradle.kts
+++ b/core/core-persistence-jooq/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import ch.ayedo.jooqmodelator.gradle.JooqModelatorTask
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.jooqModelator)
 }

--- a/core/core-pubmed-api/build.gradle.kts
+++ b/core/core-pubmed-api/build.gradle.kts
@@ -3,7 +3,19 @@ description = "SciPaMaTo-Core :: Pubmed API Project"
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.jaxb)
+    id("scipamato-integration-test")
     id("scipamato-adhoc-test")
+}
+
+testing {
+    suites {
+        val integrationTest by existing {
+            dependencies {
+                annotationProcessor(libs.lombok)
+                runtimeOnly(libs.lombok)
+            }
+        }
+    }
 }
 
 dependencies {
@@ -23,9 +35,6 @@ dependencies {
     runtimeOnly(libs.jaxb.runtime)
 
     testImplementation(project(Module.scipamatoCommon("test")))
-
-//    integrationTestAnnotationProcessor(libs.lombok)
-//    integrationTestRuntimeOnly(libs.lombok)
 }
 
 /**

--- a/core/core-pubmed-api/build.gradle.kts
+++ b/core/core-pubmed-api/build.gradle.kts
@@ -1,5 +1,6 @@
 description = "SciPaMaTo-Core :: Pubmed API Project"
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.jaxb)
 }

--- a/core/core-pubmed-api/build.gradle.kts
+++ b/core/core-pubmed-api/build.gradle.kts
@@ -3,6 +3,7 @@ description = "SciPaMaTo-Core :: Pubmed API Project"
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.jaxb)
+    id("scipamato-adhoc-test")
 }
 
 dependencies {
@@ -23,8 +24,8 @@ dependencies {
 
     testImplementation(project(Module.scipamatoCommon("test")))
 
-    integrationTestAnnotationProcessor(libs.lombok)
-    integrationTestRuntimeOnly(libs.lombok)
+//    integrationTestAnnotationProcessor(libs.lombok)
+//    integrationTestRuntimeOnly(libs.lombok)
 }
 
 /**

--- a/core/core-pubmed-api/src/adhoc-test/kotlin/ch/difty/scipamato/core/pubmed/PubmedXmlServiceIntegrationAdHocTest.kt
+++ b/core/core-pubmed-api/src/adhoc-test/kotlin/ch/difty/scipamato/core/pubmed/PubmedXmlServiceIntegrationAdHocTest.kt
@@ -10,12 +10,12 @@ import org.springframework.boot.test.context.SpringBootTest
 
 /**
  * Note: This ad-hoc integration test should not run automatically, as it
- * actually issues a call to PubMed over the internet. Thus this test fails if
+ * actually issues a call to PubMed over the internet. Thus, this test fails if
  * the machine running the test is offline or cannot reach PubMed for some other
  * reason.
  *
  *
- * Also it's not polite to continuously access the public service.
+ * Also, it's not polite to continuously access the public service.
  *
  * @author u.joss
  */

--- a/core/core-pubmed-api/src/integration-test/kotlin/ch/difty/scipamato/core/pubmed/ScipamatoPubmedArticleIntegrationTest.kt
+++ b/core/core-pubmed-api/src/integration-test/kotlin/ch/difty/scipamato/core/pubmed/ScipamatoPubmedArticleIntegrationTest.kt
@@ -91,7 +91,8 @@ internal class ScipamatoPubmedArticleIntegrationTest : PubmedIntegrationTest() {
                 "cardiovascular disease (CVD) morbidity and mortality. However, less is known " +
                 "about the populations most susceptible to these adverse effects."
             originalAbstract shouldEndWith
-                "women with diabetes were identified as the subpopulation most sensitive to the adverse cardiovascular health effects of PM."
+                "women with diabetes were identified as the subpopulation most sensitive to the " +
+                "adverse cardiovascular health effects of PM."
         }
     }
 

--- a/core/core-sync/build.gradle.kts
+++ b/core/core-sync/build.gradle.kts
@@ -1,5 +1,9 @@
 description = "SciPaMaTo-Core :: Synchronization Project"
 
+plugins{
+    id("scipamato-adhoc-test")
+}
+
 /**
  * Make the static wicket resources that reside next to the java classes in src{main,test} available.
  */
@@ -40,7 +44,7 @@ dependencies {
     testImplementation(libs.lombok)
     testAnnotationProcessor(libs.lombok)
 
-    integrationTestRuntimeOnly(libs.postgresql)
+//    integrationTestRuntimeOnly(libs.postgresql)
 }
 
 tasks {

--- a/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/jobs/language/LanguageSyncConfig.kt
+++ b/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/jobs/language/LanguageSyncConfig.kt
@@ -31,7 +31,7 @@ open class LanguageSyncConfig(
     @Qualifier("dataSource") coreDataSource: DataSource,
     jobBuilderFactory: JobBuilderFactory,
     stepBuilderFactory: StepBuilderFactory,
-    dateTimeService: DateTimeService
+    dateTimeService: DateTimeService,
 ) : SyncConfig<PublicLanguage, LanguageRecord>(
     TOPIC, CHUNK_SIZE, jooqCore, jooqPublic, coreDataSource, jobBuilderFactory, stepBuilderFactory,
     dateTimeService
@@ -63,7 +63,8 @@ open class LanguageSyncConfig(
         )
     }
 
-    override fun lastSynchedField(): TableField<LanguageRecord, Timestamp> = ch.difty.scipamato.publ.db.tables.Language.LANGUAGE.LAST_SYNCHED
+    override fun lastSynchedField(): TableField<LanguageRecord, Timestamp> =
+        ch.difty.scipamato.publ.db.tables.Language.LANGUAGE.LAST_SYNCHED
 
     companion object {
         private const val TOPIC = "language"

--- a/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/jobs/language/LanguageSyncConfig.kt
+++ b/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/jobs/language/LanguageSyncConfig.kt
@@ -59,7 +59,7 @@ open class LanguageSyncConfig(
         return PublicLanguage(
             code = getString(C_CODE, rs),
             lastSynched = getNow(),
-            mainLanguage = value != null && value,
+            mainLanguage = value,
         )
     }
 

--- a/core/core-web/build.gradle.kts
+++ b/core/core-web/build.gradle.kts
@@ -2,6 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 description = "SciPaMaTo-Core :: Web GUI Project"
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.springBoot).apply(true)
     id("application-properties-filter")

--- a/gradle-plugins/run/build.gradle.kts
+++ b/gradle-plugins/run/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     `java-gradle-plugin`
     `kotlin-dsl`

--- a/gradle-plugins/run/build.gradle.kts
+++ b/gradle-plugins/run/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     `java-gradle-plugin`

--- a/gradle-plugins/verification/build.gradle.kts
+++ b/gradle-plugins/verification/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     `java-gradle-plugin`
     `kotlin-dsl`

--- a/gradle-plugins/verification/build.gradle.kts
+++ b/gradle-plugins/verification/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     `java-gradle-plugin`

--- a/gradle-plugins/verification/build.gradle.kts
+++ b/gradle-plugins/verification/build.gradle.kts
@@ -35,5 +35,13 @@ gradlePlugin {
             id = "scipamato-jacoco"
             implementationClass = "ScipamatoJacocoPlugin"
         }
+        create("scipamato-adhoc-test") {
+            id = "scipamato-adhoc-test"
+            implementationClass = "ScipamatoAdhocTestPlugin"
+        }
+        create("scipamato-integration-test") {
+            id = "scipamato-integration-test"
+            implementationClass = "ScipamatoIntegrationTestPlugin"
+        }
     }
 }

--- a/gradle-plugins/verification/src/main/kotlin/CollectSarifPlugin.kt
+++ b/gradle-plugins/verification/src/main/kotlin/CollectSarifPlugin.kt
@@ -9,6 +9,7 @@ class CollectSarifPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.tasks.register(MERGE_DETEKT_TASK_NAME, ReportMergeTask::class.java) {
             group = JavaBasePlugin.VERIFICATION_GROUP
+            description = "Merges the detekt sarif files from the subprojects"
             output.set(project.layout.buildDirectory.file("detekt-merged.sarif"))
         }
     }

--- a/gradle-plugins/verification/src/main/kotlin/ScipamatoAdhocTestPlugin.kt
+++ b/gradle-plugins/verification/src/main/kotlin/ScipamatoAdhocTestPlugin.kt
@@ -1,0 +1,31 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JvmTestSuitePlugin
+import org.gradle.api.plugins.jvm.JvmTestSuite
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.register
+import org.gradle.testing.base.TestingExtension
+
+@Suppress("unused", "UnstableApiUsage")
+class ScipamatoAdhocTestPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply<JvmTestSuitePlugin>()
+            configure<TestingExtension> {
+                suites {
+                    register("adhocTest", JvmTestSuite::class) {
+                        sources.java.srcDir("src/adhoc-test/kotlin")
+                        dependencies {
+                            implementation(project())
+                        }
+                    }
+                }
+            }
+            configurations.named("adhocTestImplementation") {
+                extendsFrom(configurations.named("testImplementation").get())
+            }
+        }
+    }
+}

--- a/gradle-plugins/verification/src/main/kotlin/ScipamatoDetektPlugin.kt
+++ b/gradle-plugins/verification/src/main/kotlin/ScipamatoDetektPlugin.kt
@@ -31,7 +31,7 @@ class ScipamatoDetektPlugin : Plugin<Project> {
 
             // add detekt output to inputs of ReportMergeTask
             // mustRunAfter should be used here otherwise the merged report won't be generated on fail
-            rootProject.plugins.withId( "scipamato-collect-sarif") {
+            rootProject.plugins.withId("scipamato-collect-sarif") {
                 rootProject.tasks.named(
                     CollectSarifPlugin.MERGE_DETEKT_TASK_NAME,
                     ReportMergeTask::class.java

--- a/gradle-plugins/verification/src/main/kotlin/ScipamatoIntegrationTestPlugin.kt
+++ b/gradle-plugins/verification/src/main/kotlin/ScipamatoIntegrationTestPlugin.kt
@@ -5,7 +5,6 @@ import org.gradle.api.plugins.JvmTestSuitePlugin
 import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.existing
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.register
 import org.gradle.testing.base.TestingExtension
@@ -15,11 +14,9 @@ class ScipamatoIntegrationTestPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply<JvmTestSuitePlugin>()
+            val test = tasks.named("test")
             configure<TestingExtension> {
                 suites {
-                    val test = existing(JvmTestSuite::class) {
-                        useJUnitJupiter()
-                    }
                     register("integrationTest", JvmTestSuite::class) {
                         testType.set(TestSuiteType.INTEGRATION_TEST)
                         sources {

--- a/gradle-plugins/verification/src/main/kotlin/ScipamatoIntegrationTestPlugin.kt
+++ b/gradle-plugins/verification/src/main/kotlin/ScipamatoIntegrationTestPlugin.kt
@@ -1,0 +1,50 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.attributes.TestSuiteType
+import org.gradle.api.plugins.JvmTestSuitePlugin
+import org.gradle.api.plugins.jvm.JvmTestSuite
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.existing
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.register
+import org.gradle.testing.base.TestingExtension
+
+@Suppress("unused", "UnstableApiUsage")
+class ScipamatoIntegrationTestPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply<JvmTestSuitePlugin>()
+            configure<TestingExtension> {
+                suites {
+                    val test = existing(JvmTestSuite::class) {
+                        useJUnitJupiter()
+                    }
+                    register("integrationTest", JvmTestSuite::class) {
+                        testType.set(TestSuiteType.INTEGRATION_TEST)
+                        sources {
+                            java.srcDir("src/integration-test/kotlin")
+                            resources.srcDir("src/integration-test/resources")
+                        }
+                        dependencies {
+                            implementation(project())
+                        }
+                        targets {
+                            all {
+                                testTask.configure {
+                                    shouldRunAfter(test)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            configurations.named("integrationTestImplementation") {
+                extendsFrom(configurations.named("testImplementation").get())
+            }
+            tasks.named("check") {
+                dependsOn(tasks.named("integrationTest"))
+            }
+        }
+    }
+}

--- a/gradle-plugins/verification/src/main/kotlin/TestSuitePlugin.kt
+++ b/gradle-plugins/verification/src/main/kotlin/TestSuitePlugin.kt
@@ -1,2 +1,0 @@
-class TestSuitePlugin {
-}

--- a/gradle-plugins/verification/src/main/kotlin/TestSuitePlugin.kt
+++ b/gradle-plugins/verification/src/main/kotlin/TestSuitePlugin.kt
@@ -1,0 +1,2 @@
+class TestSuitePlugin {
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ springCloud = "2021.0.0"
 springCloudStarter = "3.1.6"
 springDependencyManagementPlugin = "1.1.0"
 springMockk = "3.1.2"
-testSetsPlugin = "4.0.0"
 testcontainers = "1.17.6"
 univocityParsers = "2.9.1"
 wicket = "9.12.0"
@@ -133,4 +132,3 @@ reckon = { id = "org.ajoberstar.reckon", version.ref = "reckonPlugin" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqubePlugin" }
 springBoot = { id = "org.springframework.boot", version.ref = "springBoot" }
 springDependencyManagement = { id = "io.spring.dependency-management", version.ref = "springDependencyManagementPlugin" }
-testSets = { id = "org.unbroken-dome.test-sets", version.ref = "testSetsPlugin" }

--- a/public/public-persistence-jooq/build.gradle.kts
+++ b/public/public-persistence-jooq/build.gradle.kts
@@ -51,8 +51,8 @@ dependencies {
     testImplementation(project(Module.scipamatoCommon("persistence-jooq-test")))
     testImplementation(project(Module.scipamatoCommon("test")))
 
-    integrationTestImplementation(libs.bundles.dbTest)
-    integrationTestRuntimeOnly(libs.postgresql)
+//    integrationTestImplementation(libs.bundles.dbTest)
+//    integrationTestRuntimeOnly(libs.postgresql)
 }
 
 sourceSets {

--- a/public/public-persistence-jooq/build.gradle.kts
+++ b/public/public-persistence-jooq/build.gradle.kts
@@ -5,6 +5,7 @@ import ch.ayedo.jooqmodelator.gradle.JooqModelatorTask
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.jooqModelator)
+    id("scipamato-integration-test")
 }
 
 description = "SciPaMaTo-Public:: Persistence jOOQ Project"
@@ -16,6 +17,17 @@ val generatedSourcesPath = "build/generated-src/jooq"
 val jooqConfigFile = "$buildDir/jooqConfig.xml"
 val dockerDbPort = 15432
 val props = file("src/integration-test/resources/application.properties").asProperties()
+
+testing {
+    suites {
+        val integrationTest by existing {
+            dependencies {
+                implementation(libs.bundles.dbTest)
+                runtimeOnly(libs.postgresql)
+            }
+        }
+    }
+}
 
 jooqModelator {
     jooqVersion = libs.versions.jooq.get()
@@ -50,9 +62,6 @@ dependencies {
 
     testImplementation(project(Module.scipamatoCommon("persistence-jooq-test")))
     testImplementation(project(Module.scipamatoCommon("test")))
-
-//    integrationTestImplementation(libs.bundles.dbTest)
-//    integrationTestRuntimeOnly(libs.postgresql)
 }
 
 sourceSets {

--- a/public/public-persistence-jooq/build.gradle.kts
+++ b/public/public-persistence-jooq/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import ch.ayedo.jooqmodelator.gradle.JooqModelatorTask
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.jooqModelator)
 }

--- a/public/public-web/build.gradle.kts
+++ b/public/public-web/build.gradle.kts
@@ -2,6 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 description = "SciPaMaTo-Public :: Web Project"
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.springBoot).apply(true)
     id("application-properties-filter")

--- a/public/public-web/build.gradle.kts
+++ b/public/public-web/build.gradle.kts
@@ -50,6 +50,6 @@ dependencies {
 
     testImplementation(project(Module.scipamatoCommon("test")))
 
-    integrationTestImplementation(libs.bundles.dbTest)
-    integrationTestRuntimeOnly(libs.postgresql)
+//    integrationTestImplementation(libs.bundles.dbTest)
+//    integrationTestRuntimeOnly(libs.postgresql)
 }

--- a/public/public-web/build.gradle.kts
+++ b/public/public-web/build.gradle.kts
@@ -6,7 +6,19 @@ description = "SciPaMaTo-Public :: Web Project"
 plugins {
     alias(libs.plugins.springBoot).apply(true)
     id("application-properties-filter")
+//    id("scipamato-integration-test")
 }
+
+//testing {
+//    suites {
+//        val integrationTest by existing {
+//            dependencies {
+//                implementation(libs.bundles.dbTest)
+//                runtimeOnly(libs.postgresql)
+//            }
+//        }
+//    }
+//}
 
 /**
  * Make the static wicket resources that reside next to the java classes in src{main,test} available.
@@ -49,7 +61,4 @@ dependencies {
     runtimeOnly(libs.jaxb.runtime)
 
     testImplementation(project(Module.scipamatoCommon("test")))
-
-//    integrationTestImplementation(libs.bundles.dbTest)
-//    integrationTestRuntimeOnly(libs.postgresql)
 }


### PR DESCRIPTION
As preparation for the gradle-8 migration, the test-set plugin is replaced with the jvm-test-suite plugin.

Currently, the public-web project does not run and stays disabled (to be reactivated in #116)