### PR TITLE
feat(sync): [#463] Swap labels for concatenated fields from EN to DE

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -72,8 +72,10 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 
 .Added
 
-////
 .Changed
+- {url-issues}463[#463] Synchronization from core to public to use german labels for concatenated short studies
+
+////
 
 .Deprecated
 

--- a/common/common-utils/src/main/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenator.kt
+++ b/common/common-utils/src/main/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenator.kt
@@ -22,13 +22,13 @@ abstract class AbstractShortFieldConcatenator protected constructor(private val 
         methodConfounders: String?
     ) = methodsFrom(
         method,
-        Tuple("Study Design", methodStudyDesign),
-        Tuple("Outcome", methodOutcome),
-        Tuple("Place", populationPlace),
-        Tuple("Pollutant", exposurePollutant),
-        Tuple("Exposure Assessment", exposureAssessment),
-        Tuple("Statistical Method", methodStatistics),
-        Tuple("Confounders", methodConfounders)
+        Tuple("Studiendesign", methodStudyDesign),
+        Tuple("Gesundheitliche Zielgrössen", methodOutcome),
+        Tuple("Ort/Land", populationPlace),
+        Tuple("Schadstoff", exposurePollutant),
+        Tuple("Belastungsabschätzung", exposureAssessment),
+        Tuple("Statistische Methode", methodStatistics),
+        Tuple("Störfaktoren", methodConfounders)
     )
 
     fun methodsFrom(
@@ -60,9 +60,9 @@ abstract class AbstractShortFieldConcatenator protected constructor(private val 
         populationDuration: String?
     ) = populationFrom(
         population,
-        Tuple("Place", populationPlace),
-        Tuple("Participants", populationParticipants),
-        Tuple("Study Duration", populationDuration)
+        Tuple("Ort/Land", populationPlace),
+        Tuple("Studienteilnehmer", populationParticipants),
+        Tuple("Studiendauer", populationDuration)
     )
 
     fun populationFrom(
@@ -87,10 +87,10 @@ abstract class AbstractShortFieldConcatenator protected constructor(private val 
         conclusion: String?
     ) = resultFrom(
         result,
-        Tuple("Measured Outcome", resultMeasuredOutcome),
-        Tuple("Exposure (Range)", resultExposureRange),
-        Tuple("Effect Estimate", resultEffectEstimate),
-        Tuple("Conclusion", conclusion)
+        Tuple("Gemessene Zielgrösse", resultMeasuredOutcome),
+        Tuple("Gemessene Belastung (Spanne)", resultExposureRange),
+        Tuple("Effektschätzer", resultEffectEstimate),
+        Tuple("Schlussfolgerung", conclusion)
     )
 
     fun resultFrom(

--- a/common/common-utils/src/main/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenator.kt
+++ b/common/common-utils/src/main/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenator.kt
@@ -23,7 +23,7 @@ abstract class AbstractShortFieldConcatenator protected constructor(private val 
     ) = methodsFrom(
         method,
         Tuple("Studiendesign", methodStudyDesign),
-        Tuple("Gesundheitliche Zielgrössen", methodOutcome),
+        Tuple("Zielgrössen", methodOutcome),
         Tuple("Ort/Land", populationPlace),
         Tuple("Schadstoff", exposurePollutant),
         Tuple("Belastungsabschätzung", exposureAssessment),
@@ -89,7 +89,7 @@ abstract class AbstractShortFieldConcatenator protected constructor(private val 
         result,
         Tuple("Gemessene Zielgrösse", resultMeasuredOutcome),
         Tuple("Gemessene Belastung (Spanne)", resultExposureRange),
-        Tuple("Effektschätzer", resultEffectEstimate),
+        Tuple("Resultate", resultEffectEstimate),
         Tuple("Schlussfolgerung", conclusion)
     )
 

--- a/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithNewLineTest.kt
+++ b/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithNewLineTest.kt
@@ -18,7 +18,7 @@ internal class AbstractShortFieldConcatenatorWithNewLineTest {
     fun method_withMethodNull_returnsConcatenatedShortFields() {
         concatenator.methodsFrom(null, "msd", "mo", "pp", "ep", "ea", "ms", "mc") shouldBeEqualTo
             """Studiendesign: msd
-                |Gesundheitliche Zielgrössen: mo
+                |Zielgrössen: mo
                 |Ort/Land: pp
                 |Schadstoff: ep
                 |Belastungsabschätzung: ea
@@ -86,7 +86,7 @@ internal class AbstractShortFieldConcatenatorWithNewLineTest {
     @Test
     fun result_withResultNull_returnsConcatenatedShortFields() {
         concatenator.resultFrom(null, "rmo", "rer", "ree", "cc") shouldBeEqualTo
-            "Gemessene Zielgrösse: rmo\nGemessene Belastung (Spanne): rer\nEffektschätzer: ree\nSchlussfolgerung: cc"
+            "Gemessene Zielgrösse: rmo\nGemessene Belastung (Spanne): rer\nResultate: ree\nSchlussfolgerung: cc"
     }
 
     @Test

--- a/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithNewLineTest.kt
+++ b/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithNewLineTest.kt
@@ -17,24 +17,24 @@ internal class AbstractShortFieldConcatenatorWithNewLineTest {
     @Test
     fun method_withMethodNull_returnsConcatenatedShortFields() {
         concatenator.methodsFrom(null, "msd", "mo", "pp", "ep", "ea", "ms", "mc") shouldBeEqualTo
-            """Study Design: msd
-                |Outcome: mo
-                |Place: pp
-                |Pollutant: ep
-                |Exposure Assessment: ea
-                |Statistical Method: ms
-                |Confounders: mc""".trimMargin()
+            """Studiendesign: msd
+                |Gesundheitliche Zielgrössen: mo
+                |Ort/Land: pp
+                |Schadstoff: ep
+                |Belastungsabschätzung: ea
+                |Statistische Methode: ms
+                |Störfaktoren: mc""".trimMargin()
     }
 
     @Test
     fun method_withMethodNullAndSomeShortFieldsNull_returnsConcatenatedShortFields() {
         concatenator.methodsFrom(null, "msd", null, "pp", "ep", "ea", "ms", "mc") shouldBeEqualTo
-            """Study Design: msd
-                |Place: pp
-                |Pollutant: ep
-                |Exposure Assessment: ea
-                |Statistical Method: ms
-                |Confounders: mc""".trimMargin()
+            """Studiendesign: msd
+                |Ort/Land: pp
+                |Schadstoff: ep
+                |Belastungsabschätzung: ea
+                |Statistische Methode: ms
+                |Störfaktoren: mc""".trimMargin()
     }
 
     @Test
@@ -69,7 +69,7 @@ internal class AbstractShortFieldConcatenatorWithNewLineTest {
     @Test
     fun population_withPopulationNull_returnsConcatenatedShortFields() {
         concatenator.populationFrom(null, "ppl", "ppa", "pd") shouldBeEqualTo
-            "Place: ppl\nParticipants: ppa\nStudy Duration: pd"
+            "Ort/Land: ppl\nStudienteilnehmer: ppa\nStudiendauer: pd"
     }
 
     @Test
@@ -86,7 +86,7 @@ internal class AbstractShortFieldConcatenatorWithNewLineTest {
     @Test
     fun result_withResultNull_returnsConcatenatedShortFields() {
         concatenator.resultFrom(null, "rmo", "rer", "ree", "cc") shouldBeEqualTo
-            "Measured Outcome: rmo\nExposure (Range): rer\nEffect Estimate: ree\nConclusion: cc"
+            "Gemessene Zielgrösse: rmo\nGemessene Belastung (Spanne): rer\nEffektschätzer: ree\nSchlussfolgerung: cc"
     }
 
     @Test

--- a/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithoutNewLineTest.kt
+++ b/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithoutNewLineTest.kt
@@ -18,7 +18,7 @@ internal class AbstractShortFieldConcatenatorWithoutNewLineTest {
     fun method_withMethodNull_returnsConcatenatedShortFields() {
         concatenator.methodsFrom(null, "msd", "mo", "pp", "ep", "ea", "ms", "mc")
             .shouldBeEqualTo(
-                "Studiendesign: msd / Gesundheitliche Zielgrössen: mo / Ort/Land: pp / Schadstoff: ep / " +
+                "Studiendesign: msd / Zielgrössen: mo / Ort/Land: pp / Schadstoff: ep / " +
                     "Belastungsabschätzung: ea / Statistische Methode: ms / Störfaktoren: mc"
             )
     }
@@ -87,7 +87,7 @@ internal class AbstractShortFieldConcatenatorWithoutNewLineTest {
     @Test
     fun result_withResultNull_returnsConcatenatedShortFields() {
         concatenator.resultFrom(null, "rmo", "rer", "ree", "cc") shouldBeEqualTo
-            "Gemessene Zielgrösse: rmo / Gemessene Belastung (Spanne): rer / Effektschätzer: ree / Schlussfolgerung: cc"
+            "Gemessene Zielgrösse: rmo / Gemessene Belastung (Spanne): rer / Resultate: ree / Schlussfolgerung: cc"
     }
 
     @Test

--- a/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithoutNewLineTest.kt
+++ b/common/common-utils/src/test/kotlin/ch/difty/scipamato/common/paper/AbstractShortFieldConcatenatorWithoutNewLineTest.kt
@@ -18,21 +18,21 @@ internal class AbstractShortFieldConcatenatorWithoutNewLineTest {
     fun method_withMethodNull_returnsConcatenatedShortFields() {
         concatenator.methodsFrom(null, "msd", "mo", "pp", "ep", "ea", "ms", "mc")
             .shouldBeEqualTo(
-                "Study Design: msd / Outcome: mo / Place: pp / Pollutant: ep / " +
-                    "Exposure Assessment: ea / Statistical Method: ms / Confounders: mc"
+                "Studiendesign: msd / Gesundheitliche Zielgrössen: mo / Ort/Land: pp / Schadstoff: ep / " +
+                    "Belastungsabschätzung: ea / Statistische Methode: ms / Störfaktoren: mc"
             )
     }
 
     @Test
     fun method_withMethodNull_returnsConcatenatedShortFieldsWhereNotBlank() {
         concatenator.methodsFrom(null, "", " ", "pp", "ep", "ea", "ms", "mc") shouldBeEqualTo
-            "Place: pp / Pollutant: ep / Exposure Assessment: ea / Statistical Method: ms / Confounders: mc"
+            "Ort/Land: pp / Schadstoff: ep / Belastungsabschätzung: ea / Statistische Methode: ms / Störfaktoren: mc"
     }
 
     @Test
     fun method_withMethodNullAndSomeShortFieldsNull_returnsConcatenatedShortFields() {
         concatenator.methodsFrom(null, "msd", null, "pp", "ep", "ea", "ms", "mc") shouldBeEqualTo
-            "Study Design: msd / Place: pp / Pollutant: ep / Exposure Assessment: ea / Statistical Method: ms / Confounders: mc"
+            "Studiendesign: msd / Ort/Land: pp / Schadstoff: ep / Belastungsabschätzung: ea / Statistische Methode: ms / Störfaktoren: mc"
     }
 
     @Test
@@ -70,7 +70,7 @@ internal class AbstractShortFieldConcatenatorWithoutNewLineTest {
     @Test
     fun population_withPopulationNull_returnsConcatenatedShortFields() {
         concatenator.populationFrom(null, "ppl", "ppa", "pd") shouldBeEqualTo
-            "Place: ppl / Participants: ppa / Study Duration: pd"
+            "Ort/Land: ppl / Studienteilnehmer: ppa / Studiendauer: pd"
     }
 
     @Test
@@ -87,7 +87,7 @@ internal class AbstractShortFieldConcatenatorWithoutNewLineTest {
     @Test
     fun result_withResultNull_returnsConcatenatedShortFields() {
         concatenator.resultFrom(null, "rmo", "rer", "ree", "cc") shouldBeEqualTo
-            "Measured Outcome: rmo / Exposure (Range): rer / Effect Estimate: ree / Conclusion: cc"
+            "Gemessene Zielgrösse: rmo / Gemessene Belastung (Spanne): rer / Effektschätzer: ree / Schlussfolgerung: cc"
     }
 
     @Test

--- a/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/jobs/paper/SyncShortFieldConcatenator.kt
+++ b/core/core-sync/src/main/kotlin/ch/difty/scipamato/core/sync/jobs/paper/SyncShortFieldConcatenator.kt
@@ -3,7 +3,7 @@ package ch.difty.scipamato.core.sync.jobs.paper
 import java.sql.ResultSet
 
 /**
- * Gathers the content for the the fields methods, population and result based on a resultSet of papers.
+ * Gathers the content for the the fields `methods`, `population` and `result` based on a resultSet of papers.
  * The content may either be those fields themselves or some concatenated short fields.
  */
 interface SyncShortFieldConcatenator {

--- a/core/core-sync/src/test/kotlin/ch/difty/scipamato/core/sync/jobs/paper/SyncShortFieldWithEmptyMainFieldConcatenatorTest.kt
+++ b/core/core-sync/src/test/kotlin/ch/difty/scipamato/core/sync/jobs/paper/SyncShortFieldWithEmptyMainFieldConcatenatorTest.kt
@@ -71,7 +71,7 @@ internal class SyncShortFieldWithEmptyMainFieldConcatenatorTest {
     fun methods_withNullMethod_returnsConcatenatedShortMethodFieldsConcatenated() {
         stubMethodFieldsWithMainFieldReturning(null)
         sfc.methodsFrom(resultSet) shouldBeEqualTo
-            "Studiendesign: msd / Gesundheitliche Zielgrössen: mo / Ort/Land: pp / Schadstoff: ep / " +
+            "Studiendesign: msd / Zielgrössen: mo / Ort/Land: pp / Schadstoff: ep / " +
             "Belastungsabschätzung: ea / Statistische Methode: ms / Störfaktoren: mc"
         verifyCallingMethodsFields()
     }
@@ -150,7 +150,7 @@ internal class SyncShortFieldWithEmptyMainFieldConcatenatorTest {
     fun result_withNullResult_returnsResultShortFieldsConcatenated() {
         stubResultFieldsWithMainFieldReturning(null)
         sfc.resultFrom(resultSet) shouldBeEqualTo
-            "Gemessene Zielgrösse: rmo / Gemessene Belastung (Spanne): rer / Effektschätzer: ree / Schlussfolgerung: cc"
+            "Gemessene Zielgrösse: rmo / Gemessene Belastung (Spanne): rer / Resultate: ree / Schlussfolgerung: cc"
         verifyCallingResultFields()
     }
 

--- a/core/core-sync/src/test/kotlin/ch/difty/scipamato/core/sync/jobs/paper/SyncShortFieldWithEmptyMainFieldConcatenatorTest.kt
+++ b/core/core-sync/src/test/kotlin/ch/difty/scipamato/core/sync/jobs/paper/SyncShortFieldWithEmptyMainFieldConcatenatorTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.jooq.TableField
@@ -70,8 +71,8 @@ internal class SyncShortFieldWithEmptyMainFieldConcatenatorTest {
     fun methods_withNullMethod_returnsConcatenatedShortMethodFieldsConcatenated() {
         stubMethodFieldsWithMainFieldReturning(null)
         sfc.methodsFrom(resultSet) shouldBeEqualTo
-            "Study Design: msd / Outcome: mo / Place: pp / Pollutant: ep / " +
-            "Exposure Assessment: ea / Statistical Method: ms / Confounders: mc"
+            "Studiendesign: msd / Gesundheitliche Zielgrössen: mo / Ort/Land: pp / Schadstoff: ep / " +
+            "Belastungsabschätzung: ea / Statistische Methode: ms / Störfaktoren: mc"
         verifyCallingMethodsFields()
     }
 
@@ -114,7 +115,7 @@ internal class SyncShortFieldWithEmptyMainFieldConcatenatorTest {
     @Test
     fun population_withNullPopulation_returnsPopulationShortFieldsConcatenated() {
         stubPopulationFieldsWithMainFieldReturning(null)
-        sfc.populationFrom(resultSet) shouldBeEqualTo "Place: ppl / Participants: ppa / Study Duration: pd"
+        sfc.populationFrom(resultSet) shouldBeEqualTo "Ort/Land: ppl / Studienteilnehmer: ppa / Studiendauer: pd"
         verifyCallingPopulationFields()
     }
 
@@ -149,7 +150,7 @@ internal class SyncShortFieldWithEmptyMainFieldConcatenatorTest {
     fun result_withNullResult_returnsResultShortFieldsConcatenated() {
         stubResultFieldsWithMainFieldReturning(null)
         sfc.resultFrom(resultSet) shouldBeEqualTo
-            "Measured Outcome: rmo / Exposure (Range): rer / Effect Estimate: ree / Conclusion: cc"
+            "Gemessene Zielgrösse: rmo / Gemessene Belastung (Spanne): rer / Effektschätzer: ree / Schlussfolgerung: cc"
         verifyCallingResultFields()
     }
 


### PR DESCRIPTION
When sychronizing from core to public, the short fields are concatenated and fed into the regular fields (mehtods, population, results). There is a caption/label prepended to each field content. As this concatenation happens on synchronization time and not at view time, those labels do not respond to the browser locale set by the viewer.

The initial choice was to use english labels. The team now requested to switch the labels to german.