### PR TITLE
chore: let scipamato run on jvm 17

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,8 +13,12 @@ on:
 
 jobs:
   build:
-
+    strategy:
+      matrix:
+        jdk: [11, 17]
     runs-on: ubuntu-latest
+    env:
+      JDK_VERSION: ${{ matrix.jdk }}
 
     steps:
     - name: Checkout repository
@@ -23,11 +27,11 @@ jobs:
     - name: Gradle wrapper validation
       uses: gradle/wrapper-validation-action@v1
       
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.jdk }}
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: '11'
+        java-version: ${{ matrix.jdk }}
 
     - name: Cache SonarCloud packages
       uses: actions/cache@v3

--- a/common/common-persistence-jooq/src/test/kotlin/ch/difty/scipamato/common/persistence/SortMapperTest.kt
+++ b/common/common-persistence-jooq/src/test/kotlin/ch/difty/scipamato/common/persistence/SortMapperTest.kt
@@ -83,7 +83,6 @@ internal class SortMapperTest {
         verify { mapperSpy.getTableFieldFor(tableMock, "FIELD2") }
     }
 
-    @Suppress("SpellCheckingInspection")
     @Test
     fun mapping_withWrongFieldName_throwsInvalidDataAccessApiUsageException() {
         sortProps.add(SortProperty("inexistentField", Direction.ASC))

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqEntityRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqEntityRepo.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jooq.Record;
 import org.jooq.*;
 import org.slf4j.Logger;
 

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqReadOnlyRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/JooqReadOnlyRepo.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jooq.Record;
 import org.jooq.*;
 
 import ch.difty.scipamato.common.DateTimeService;
@@ -59,8 +60,8 @@ public abstract class JooqReadOnlyRepo<R extends Record, T extends CoreEntity, I
      *     the object providing the application properties
      */
     protected JooqReadOnlyRepo(@NotNull final DSLContext dsl, @NotNull final M mapper, @NotNull final JooqSortMapper<R, T, TI> sortMapper,
-        @NotNull GenericFilterConditionMapper<F> filterConditionMapper, @NotNull DateTimeService dateTimeService,
-        @NotNull ApplicationProperties applicationProperties) {
+        @NotNull final GenericFilterConditionMapper<F> filterConditionMapper, @NotNull final DateTimeService dateTimeService,
+        @NotNull final ApplicationProperties applicationProperties) {
         super(dsl, dateTimeService);
 
         this.mapper = mapper;
@@ -113,7 +114,7 @@ public abstract class JooqReadOnlyRepo<R extends Record, T extends CoreEntity, I
 
     @NotNull
     @Override
-    public List<T> findAll(@Nullable String languageCode) {
+    public List<T> findAll(@Nullable final String languageCode) {
         final List<T> entities = getDsl()
             .selectFrom(getTable())
             .fetch(getMapper());
@@ -136,7 +137,7 @@ public abstract class JooqReadOnlyRepo<R extends Record, T extends CoreEntity, I
     @Nullable
     @Override
     public T findById(@NotNull final ID id, @Nullable final String languageCode) {
-        T entity = getDsl()
+        final T entity = getDsl()
             .selectFrom(getTable())
             .where(getTableId().equal(id))
             .fetchOne(getMapper());

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/newsletter/JooqNewsletterRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/newsletter/JooqNewsletterRepo.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jooq.Record;
 import org.jooq.*;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -176,8 +177,7 @@ public class JooqNewsletterRepo extends
     }
 
     // package-private for testing purposes
-    @NotNull
-    Optional<Paper.NewsletterLink> handleInsertedNewsletter(final int count, final int newsletterId, final long paperId,
+    @NotNull Optional<Paper.NewsletterLink> handleInsertedNewsletter(final int count, final int newsletterId, final long paperId,
         @NotNull final String languageCode) {
         if (count > 0) {
             final Record6<Integer, String, Integer, Integer, String, String> r = fetchMergedNewsletter(newsletterId, paperId, languageCode);
@@ -188,8 +188,7 @@ public class JooqNewsletterRepo extends
     }
 
     // package-private for stubbing purposes
-    @Nullable
-    Record6<Integer, String, Integer, Integer, String, String> fetchMergedNewsletter(final int newsletterId, final long paperId,
+    @Nullable Record6<Integer, String, Integer, Integer, String, String> fetchMergedNewsletter(final int newsletterId, final long paperId,
         @NotNull final String languageCode) {
         return getDsl()
             .select(NEWSLETTER.ID, NEWSLETTER.ISSUE, NEWSLETTER.PUBLICATION_STATUS, NEWSLETTER_TOPIC.ID, NEWSLETTER_TOPIC_TR.TITLE,

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/JooqPaperRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/JooqPaperRepo.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jooq.Record;
 import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
@@ -484,8 +485,7 @@ public class JooqPaperRepo extends JooqEntityRepo<PaperRecord, Paper, Long, ch.d
             return condition;
     }
 
-    @NotNull
-    Optional<String> evaluateNumbers(@Nullable final Record1<Long[]> numbers) {
+    @NotNull Optional<String> evaluateNumbers(@Nullable final Record1<Long[]> numbers) {
         if (numbers == null || numbers.value1() == null || numbers.value1().length == 0)
             return Optional.empty();
         return Optional.of(Arrays

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/searchorder/JooqBySearchOrderRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/searchorder/JooqBySearchOrderRepo.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
+import org.jooq.Record;
 import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -212,7 +213,9 @@ public abstract class JooqBySearchOrderRepo<T extends IdScipamatoEntity<Long>, M
 
     @NotNull
     private Condition evaluateStringSearchTerm(final TableField<?, String> field, final String value) {
-        final StringSearchTerm st = SearchTerm.newStringSearchTerm(field.getQualifiedName().toString(), value);
+        final StringSearchTerm st = SearchTerm.newStringSearchTerm(field
+            .getQualifiedName()
+            .toString(), value);
         return stringSearchTermEvaluator.evaluate(st);
     }
 
@@ -223,8 +226,8 @@ public abstract class JooqBySearchOrderRepo<T extends IdScipamatoEntity<Long>, M
             .from(PAPER_ATTACHMENT)
             .where(PAPER_ATTACHMENT.PAPER_ID.eq(PAPER.ID));
         if (sc.getAttachmentNameMask() != null) {
-            final SelectConditionStep<Record1<Integer>> step1 =
-                step0.and(evaluateStringSearchTerm(PAPER_ATTACHMENT.NAME, sc.getAttachmentNameMask()));
+            final SelectConditionStep<Record1<Integer>> step1 = step0.and(
+                evaluateStringSearchTerm(PAPER_ATTACHMENT.NAME, sc.getAttachmentNameMask()));
             attConditions.add(() -> DSL.exists(step1));
         } else if (sc.getHasAttachments() != null) {
             if (Boolean.TRUE.equals(sc.getHasAttachments()))

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/slim/JooqPaperSlimRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/paper/slim/JooqPaperSlimRepo.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jooq.Record;
 import org.jooq.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
@@ -29,18 +30,17 @@ import ch.difty.scipamato.core.persistence.paper.searchorder.PaperSlimBackedSear
 
 @Repository
 @Profile("!wickettest")
-public class JooqPaperSlimRepo extends
-    JooqReadOnlyRepo<PaperRecord, PaperSlim, Long, ch.difty.scipamato.core.db.tables.Paper, PaperSlimRecordMapper, PaperFilter>
+public class JooqPaperSlimRepo
+    extends JooqReadOnlyRepo<PaperRecord, PaperSlim, Long, ch.difty.scipamato.core.db.tables.Paper, PaperSlimRecordMapper, PaperFilter>
     implements PaperSlimRepository {
 
     private final PaperSlimBackedSearchOrderRepository searchOrderRepository;
 
-    public JooqPaperSlimRepo(@Qualifier("dslContext") @NotNull final DSLContext dsl,
-        @NotNull final PaperSlimRecordMapper mapper,
+    public JooqPaperSlimRepo(@Qualifier("dslContext") @NotNull final DSLContext dsl, @NotNull final PaperSlimRecordMapper mapper,
         @NotNull final JooqSortMapper<PaperRecord, PaperSlim, ch.difty.scipamato.core.db.tables.Paper> sortMapper,
         @NotNull final GenericFilterConditionMapper<PaperFilter> filterConditionMapper,
-        @NotNull final PaperSlimBackedSearchOrderRepository searchOrderRepository,
-        @NotNull final DateTimeService dateTimeService, @NotNull final ApplicationProperties applicationProperties) {
+        @NotNull final PaperSlimBackedSearchOrderRepository searchOrderRepository, @NotNull final DateTimeService dateTimeService,
+        @NotNull final ApplicationProperties applicationProperties) {
         super(dsl, mapper, sortMapper, filterConditionMapper, dateTimeService, applicationProperties);
         this.searchOrderRepository = searchOrderRepository;
     }
@@ -70,16 +70,16 @@ public class JooqPaperSlimRepo extends
             .where(getTableId().equal(id))
             .fetchOne();
         if (record != null)
-            return new PaperSlim(record.value1(), record.value2(), record.value3(), record.value4(), record.value5(),
-                record.value6(), record.value7(), getStatusId(record), record.value9());
+            return new PaperSlim(record.value1(), record.value2(), record.value3(), record.value4(), record.value5(), record.value6(),
+                record.value7(), getStatusId(record), record.value9());
         else
             return null;
     }
 
     private SelectOnConditionStep<Record9<Long, Long, String, Integer, String, Integer, String, Integer, String>> getBaseQuery() {
         return getDsl()
-            .select(PAPER.ID, PAPER.NUMBER, PAPER.FIRST_AUTHOR, PAPER.PUBLICATION_YEAR, PAPER.TITLE, NEWSLETTER.ID,
-                NEWSLETTER.ISSUE, NEWSLETTER.PUBLICATION_STATUS, PAPER_NEWSLETTER.HEADLINE)
+            .select(PAPER.ID, PAPER.NUMBER, PAPER.FIRST_AUTHOR, PAPER.PUBLICATION_YEAR, PAPER.TITLE, NEWSLETTER.ID, NEWSLETTER.ISSUE,
+                NEWSLETTER.PUBLICATION_STATUS, PAPER_NEWSLETTER.HEADLINE)
             .from(PAPER)
             .leftOuterJoin(PAPER_NEWSLETTER)
             .on(PAPER.ID.eq(PAPER_NEWSLETTER.PAPER_ID))
@@ -87,14 +87,13 @@ public class JooqPaperSlimRepo extends
             .on(PAPER_NEWSLETTER.NEWSLETTER_ID.eq(NEWSLETTER.ID));
     }
 
-    private int getStatusId(
-        final Record9<Long, Long, String, Integer, String, Integer, String, Integer, String> record) {
+    private int getStatusId(final Record9<Long, Long, String, Integer, String, Integer, String, Integer, String> record) {
         return record.get(NEWSLETTER.PUBLICATION_STATUS.getName(), Integer.class);
     }
 
     @Nullable
     @Override
-    public PaperSlim findById(@NotNull final Long id, final int version, @Nullable String languageCode) {
+    public PaperSlim findById(@NotNull final Long id, final int version, @Nullable final String languageCode) {
         final Record9<Long, Long, String, Integer, String, Integer, String, Integer, String> record = getBaseQuery()
             .where(getTableId().equal(id))
             .and(getRecordVersion().equal(version))
@@ -107,27 +106,24 @@ public class JooqPaperSlimRepo extends
 
     @NotNull
     @Override
-    public List<PaperSlim> findAll(@Nullable String languageCode) {
+    public List<PaperSlim> findAll(@Nullable final String languageCode) {
         final List<PaperSlim> results = new ArrayList<>();
         for (final Record9<Long, Long, String, Integer, String, Integer, String, Integer, String> r : getBaseQuery().fetch())
             results.add(newPaperSlim(r));
         return results;
     }
 
-    private PaperSlim newPaperSlim(
-        final Record9<Long, Long, String, Integer, String, Integer, String, Integer, String> r) {
+    private PaperSlim newPaperSlim(final Record9<Long, Long, String, Integer, String, Integer, String, Integer, String> r) {
         final Integer newsletterId = r.value6();
         if (newsletterId != null)
-            return new PaperSlim(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(), newsletterId, r.value7(),
-                getStatusId(r), r.value9());
+            return new PaperSlim(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(), newsletterId, r.value7(), getStatusId(r), r.value9());
         else
             return new PaperSlim(r.value1(), r.value2(), r.value3(), r.value4(), r.value5());
     }
 
     @NotNull
     @Override
-    public List<PaperSlim> findPageByFilter(final PaperFilter filter, @NotNull final PaginationContext pc,
-        @Nullable final String languageCode) {
+    public List<PaperSlim> findPageByFilter(final PaperFilter filter, @NotNull final PaginationContext pc, @Nullable final String languageCode) {
         final List<PaperSlim> results = new ArrayList<>();
         final Condition conditions = getFilterConditionMapper().map(filter);
         final Collection<SortField<PaperSlim>> sortCriteria = getSortMapper().map(pc.getSort(), getTable());
@@ -151,15 +147,14 @@ public class JooqPaperSlimRepo extends
 
     @NotNull
     @Override
-    public List<PaperSlim> findPageBySearchOrder(@NotNull SearchOrder searchOrder,
-        @NotNull PaginationContext paginationContext) {
+    public List<PaperSlim> findPageBySearchOrder(@NotNull final SearchOrder searchOrder, @NotNull final PaginationContext paginationContext) {
         final List<PaperSlim> entities = searchOrderRepository.findPageBySearchOrder(searchOrder, paginationContext);
         enrichAssociatedEntitiesOfAll(entities, null);
         return entities;
     }
 
     @Override
-    public int countBySearchOrder(@NotNull SearchOrder searchOrder) {
+    public int countBySearchOrder(@NotNull final SearchOrder searchOrder) {
         return searchOrderRepository.countBySearchOrder(searchOrder);
     }
 }

--- a/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/search/JooqSearchOrderRepo.java
+++ b/core/core-persistence-jooq/src/main/java/ch/difty/scipamato/core/persistence/search/JooqSearchOrderRepo.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jooq.Record;
 import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
@@ -217,8 +218,7 @@ public class JooqSearchOrderRepo extends
     }
 
     // package-private for testing purposes
-    @NotNull
-    List<SearchCondition> findTermLessConditions(@NotNull final Map<Long, SearchCondition> idToSc,
+    @NotNull List<SearchCondition> findTermLessConditions(@NotNull final Map<Long, SearchCondition> idToSc,
         @NotNull final List<Long> conditionIdsWithSearchTerms) {
         return idToSc
             .values()
@@ -433,8 +433,7 @@ public class JooqSearchOrderRepo extends
      *     identifying the search order
      * @return optional of the persisted version (if found - empty otherwise)
      */
-    @NotNull
-    Optional<SearchCondition> findEquivalentPersisted(@NotNull final SearchCondition searchCondition, final long searchOrderId,
+    @NotNull Optional<SearchCondition> findEquivalentPersisted(@NotNull final SearchCondition searchCondition, final long searchOrderId,
         @NotNull final String languageCode) {
         final List<SearchCondition> persisted = getDsl()
             .selectFrom(SEARCH_CONDITION)


### PR DESCRIPTION
In order to let SciPaMaTo run on a JVM 17 (still compiled to java 11), explicit imports for org.jooq.Record seem to be necessary.

Also applies formats to repos.