### PR TITLE
chore: fail on gradle warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ subprojects {
 
     testing {
         suites {
-            @Suppress("UnstableApiUsage", "UNUSED_VARIABLE")
+            @Suppress("UnstableApiUsage", "unused")
             val test by getting(JvmTestSuite::class) {
                 useJUnitJupiter()
             }
@@ -198,6 +198,7 @@ tasks {
     }
 }
 
+@Suppress("MaxLineLength")
 downloadLicenses {
     dependencyConfiguration = "runtimeClasspath"
     includeProjectDependencies = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,9 +56,10 @@ jacoco {
     toolVersion = libs.versions.jacoco.get()
 }
 
-val jacocoTestReportFile = "$buildDir/reports/jacoco/test/jacocoTestReport.xml"
+val jacocoTestReportFile = layout.buildDirectory.get().asFile.resolve("reports/jacoco/test/jacocoTestReport.xml")
 val jacocoTestPattern = "**/build/jacoco/*.exec"
 val genPkg = generatedPackages.joinToString(",")
+val detektReportFile = layout.buildDirectory.get().asFile.resolve("reports/detekt/detekt.xml")
 
 sonarqube {
     properties {
@@ -68,7 +69,7 @@ sonarqube {
         property("sonar.exclusions", "**/ch/difty/scipamato/publ/web/themes/markup/html/publ/**/*,$genPkg")
         property("sonar.coverage.exclusions", (generatedPackages + testPackages).joinToString(","))
         property("sonar.coverage.jacoco.xmlReportPaths", jacocoTestReportFile)
-        property("sonar.kotlin.detekt.reportPaths", "$buildDir/reports/detekt/detekt.xml")
+        property("sonar.kotlin.detekt.reportPaths", detektReportFile)
     }
 }
 

--- a/core/core-persistence-jooq/build.gradle.kts
+++ b/core/core-persistence-jooq/build.gradle.kts
@@ -20,7 +20,7 @@ val props = file("src/integration-test/resources/application.properties").asProp
 
 testing {
     suites {
-        @Suppress("UNUSED_VARIABLE")
+        @Suppress("unused")
         val integrationTest by existing {
             dependencies {
                 implementation(libs.bundles.dbTest)

--- a/core/core-persistence-jooq/build.gradle.kts
+++ b/core/core-persistence-jooq/build.gradle.kts
@@ -14,7 +14,7 @@ val moduleName = "core/core-persistence-jooq"
 val dbPackageName = "ch.difty.scipamato.core.db"
 val dbPackagePath get() = dbPackageName.replace('.', '/')
 val generatedSourcesPath = "build/generated-src/jooq"
-val jooqConfigFile = "$buildDir/jooqConfig.xml"
+val jooqConfigFile = layout.buildDirectory.get().asFile.resolve("jooqConfig.xml")
 val dockerDbPort = 15432
 val props = file("src/integration-test/resources/application.properties").asProperties()
 
@@ -35,7 +35,7 @@ jooqModelator {
     jooqVersion = libs.versions.jooq.get()
     jooqEdition = "OSS"
 
-    jooqConfigPath = jooqConfigFile
+    jooqConfigPath = jooqConfigFile.absolutePath
     jooqOutputPath = "$generatedSourcesPath/$dbPackagePath"
 
     migrationEngine = "FLYWAY"
@@ -121,7 +121,7 @@ tasks {
     val jooqMetamodelTaskName = "generateJooqMetamodel"
     withType<JooqModelatorTask> {
         // prevent parallel run of this task between core and public
-        outputs.dir("${rootProject.buildDir}/$jooqMetamodelTaskName")
+        outputs.dir(rootProject.layout.buildDirectory.get().asFile.resolve(jooqMetamodelTaskName))
         dependsOn(processResources)
     }
     getByName("compileKotlin").dependsOn += jooqMetamodelTaskName

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1G
 
 systemProp.sonar.projectKey=ursjoss_scipamato
+systemProp.sonar.skipCompile=true
+
 group = ch.difty
 
 org.gradle.kotlin.dsl.allWarningsAsErrors=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=1G
 
 systemProp.sonar.projectKey=ursjoss_scipamato
 group = ch.difty
+
+org.gradle.kotlin.dsl.allWarningsAsErrors=true

--- a/public/public-persistence-jooq/build.gradle.kts
+++ b/public/public-persistence-jooq/build.gradle.kts
@@ -20,7 +20,7 @@ val props = file("src/integration-test/resources/application.properties").asProp
 
 testing {
     suites {
-        @Suppress("UNUSED_VARIABLE")
+        @Suppress("unused")
         val integrationTest by existing {
             dependencies {
                 implementation(libs.bundles.dbTest)

--- a/public/public-persistence-jooq/build.gradle.kts
+++ b/public/public-persistence-jooq/build.gradle.kts
@@ -14,7 +14,7 @@ val moduleName = "public/public-persistence-jooq"
 val dbPackageName = "ch.difty.scipamato.publ.db"
 val dbPackagePath get() = dbPackageName.replace('.', '/')
 val generatedSourcesPath = "build/generated-src/jooq"
-val jooqConfigFile = "$buildDir/jooqConfig.xml"
+val jooqConfigFile = layout.buildDirectory.get().asFile.resolve("jooqConfig.xml")
 val dockerDbPort = 15432
 val props = file("src/integration-test/resources/application.properties").asProperties()
 
@@ -34,7 +34,7 @@ jooqModelator {
     jooqVersion = libs.versions.jooq.get()
     jooqEdition = "OSS"
 
-    jooqConfigPath = jooqConfigFile
+    jooqConfigPath = jooqConfigFile.absolutePath
     jooqOutputPath = "$generatedSourcesPath/$dbPackagePath"
 
     migrationEngine = "FLYWAY"
@@ -115,7 +115,7 @@ tasks {
     val jooqMetamodelTaskName = "generateJooqMetamodel"
     withType<JooqModelatorTask> {
         // prevent parallel run of this task between core and public
-        outputs.dir("${rootProject.buildDir}/$jooqMetamodelTaskName")
+        outputs.dir(rootProject.layout.buildDirectory.get().asFile.resolve(jooqMetamodelTaskName))
         dependsOn(processResources)
     }
     getByName("compileKotlin").dependsOn += jooqMetamodelTaskName


### PR DESCRIPTION
- have gradle fail the build for gradle warnings
- resolve current warnings
- resolve some detekt warnings
- set property `sonar.skipCompile` to `true`  (see [here](https://sonarsource.atlassian.net/browse/SONARGRADL-130))