### PR TITLE
chore!: Bump postgres from 10.6 to 15.4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,7 +55,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Download postgres
-      run: docker pull postgres:10
+      run: docker pull postgres:15.4
 
     - name: Build
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Download postgres
-      run: docker pull postgres:10
+      run: docker pull postgres:15.4
 
     - name: Build
       uses: gradle/gradle-build-action@v2

--- a/core/core-persistence-jooq/build.gradle.kts
+++ b/core/core-persistence-jooq/build.gradle.kts
@@ -41,7 +41,7 @@ jooqModelator {
     migrationEngine = "FLYWAY"
     migrationsPaths = listOf("$rootDir/$moduleName/src/main/resources/db/migration/")
 
-    dockerTag = "postgres:10"
+    dockerTag = "postgres:15.4"
 
     dockerEnv = listOf(
         "POSTGRES_DB=${props.getProperty("db.name")}",

--- a/core/core-persistence-jooq/src/integration-test/resources/application.properties
+++ b/core/core-persistence-jooq/src/integration-test/resources/application.properties
@@ -12,7 +12,7 @@ db.port=5432
 # we need the driver-class-name to trigger the creation of a connection pool
 # see https://github.com/spring-projects/spring-boot/issues/6907
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:10.6://localhost:${db.port}/${db.name}
+spring.datasource.url=jdbc:tc:postgresql:15.4://localhost:${db.port}/${db.name}
 
 spring.datasource.hikari.driver-class-name=${spring.datasource.driver-class-name}
 spring.datasource.hikari.jdbc-url=${spring.datasource.url}

--- a/public/public-persistence-jooq/build.gradle.kts
+++ b/public/public-persistence-jooq/build.gradle.kts
@@ -40,7 +40,7 @@ jooqModelator {
     migrationEngine = "FLYWAY"
     migrationsPaths = listOf("$rootDir/$moduleName/src/main/resources/db/migration/")
 
-    dockerTag = "postgres:10"
+    dockerTag = "postgres:15.4"
 
     dockerEnv = listOf(
         "POSTGRES_DB=${props.getProperty("db.name")}",

--- a/public/public-persistence-jooq/src/integration-test/resources/application.properties
+++ b/public/public-persistence-jooq/src/integration-test/resources/application.properties
@@ -12,7 +12,7 @@ db.port=5432
 # we need the driver-class-name to trigger the creation of a connection pool
 # see https://github.com/spring-projects/spring-boot/issues/6907
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:10.6://localhost:${db.port}/${db.name}
+spring.datasource.url=jdbc:tc:postgresql:15.4://localhost:${db.port}/${db.name}
 
 spring.datasource.hikari.driver-class-name=${spring.datasource.driver-class-name}
 spring.datasource.hikari.jdbc-url=${spring.datasource.url}

--- a/public/public-persistence-jooq/src/main/resources/db/migration/V181030081000__new_study_topic_fk_fix.sql
+++ b/public/public-persistence-jooq/src/main/resources/db/migration/V181030081000__new_study_topic_fk_fix.sql
@@ -6,8 +6,8 @@ ALTER TABLE new_study_topic
 
 -- replace non cascading foreign key on new_study_topic with cascading one
 ALTER TABLE new_study
-  DROP CONSTRAINT new_study_newsletter_id_fkey,
-  ADD CONSTRAINT new_study_new_study_topic_newsletter_id_newsletter_topic_id_fkey
+  DROP CONSTRAINT IF EXISTS new_study_newsletter_id_fkey,
+  ADD CONSTRAINT new_study_new_study_topic_newsletter_id_nl_topic_id_fkey
 FOREIGN KEY (newsletter_id, newsletter_topic_id)
 REFERENCES new_study_topic (newsletter_id, newsletter_topic_id)
 ON DELETE CASCADE ON UPDATE CASCADE;

--- a/public/public-web/src/integration-test/kotlin/ch/difty/scipamato/publ/config/HikariDatasourceProductionSettingsIntegrationTest.kt
+++ b/public/public-web/src/integration-test/kotlin/ch/difty/scipamato/publ/config/HikariDatasourceProductionSettingsIntegrationTest.kt
@@ -18,7 +18,7 @@ internal class HikariDatasourceProductionSettingsIntegrationTest : AbstractInteg
     fun jdbcUrl() {
         datasource shouldBeInstanceOf HikariDataSource::class
         val ds = datasource as HikariDataSource
-        ds.jdbcUrl shouldBeEqualTo "jdbc:tc:postgresql:10.6://localhost:5432/scipamato_public"
+        ds.jdbcUrl shouldBeEqualTo "jdbc:tc:postgresql:15.4://localhost:5432/scipamato_public"
     }
 
     @Test

--- a/public/public-web/src/integration-test/resources/application.properties
+++ b/public/public-web/src/integration-test/resources/application.properties
@@ -40,7 +40,7 @@ db.port=5432
 # we need the driver-class-name to trigger the creation of a connection pool
 # see https://github.com/spring-projects/spring-boot/issues/6907
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:10.6://localhost:${db.port}/${db.name}
+spring.datasource.url=jdbc:tc:postgresql:15.4://localhost:${db.port}/${db.name}
 
 spring.datasource.hikari.driver-class-name=${spring.datasource.driver-class-name}
 spring.datasource.hikari.jdbc-url=${spring.datasource.url}


### PR DESCRIPTION
After upgrade of production instance of Scipamato from 10.6 to 15.4, we can bump the build implementations and the documentation too.

Note, for some reason, public flyway script `V181030081000__new_study_topic_fk_fix` tries to delete a constraint that does not exist (anymore). I added the `if exists` clause and also renamed the new index to not use too many characters (a warning so far).

However, if this fix is applied to a database that already ran the original patch, flyway will fail.

One will manually have to fix the checksum in the public database. I.e. as user `postgres` (adjust the database name from "scipamato_public" to whatever the name of the public database actually is):

```
psql
\c scipamato_public
update flyway_schema_history set checksum = 1627436357 where version = '181030081000' and checksum = -1656503799;
```