### PR TITLE
fix: [#701] Fix deleting attachments with long names

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -71,7 +71,6 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 
 .Added
 
-////
 .Changed
 
 .Deprecated
@@ -79,7 +78,9 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Removed
 
 .Fixed
+- {url-issues}701[#701] Fix deletion of attachments with very long names
 
+////
 .Security
 
 ////

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel$TabPanel6.html
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/common/PaperPanel$TabPanel6.html
@@ -5,10 +5,9 @@
 <wicket:panel>
     <form wicket:id="tab6Form">
         <div class="row">
-            <div class="col-sm-6 col-md-6">
+            <div class="col-sm-12 col-md-12">
                 <table class="dataview" wicket:id="attachments"></table>
             </div>
-            <div class="col-md-6"></div>
         </div>
         <div class="row">
             <div class="col-sm-6 col-md-6">


### PR DESCRIPTION
Fixes #701