### PR TITLE
fix: [#708] Keep back-button hidden in public detail page after opening from search list

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -79,6 +79,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 
 .Fixed
 - {url-issues}701[#701] Fix deletion of attachments with very long names
+- {url-issues}708[#708] Keep back-button hidden in public detail page after opening from search list
 
 ////
 .Security

--- a/public/public-web/src/main/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPaperDetailPage.kt
+++ b/public/public-web/src/main/kotlin/ch/difty/scipamato/publ/web/paper/browse/PublicPaperDetailPage.kt
@@ -114,7 +114,7 @@ class PublicPaperDetailPage : BasePage<PublicPaper> {
         override fun onSubmit() {
             getId()?.let {
                 pageParameters[PublicPageParameters.NUMBER.parameterName] = it
-                setResponsePage(PublicPaperDetailPage(pageParameters, callingPageRef))
+                setResponsePage(PublicPaperDetailPage(pageParameters, callingPageRef, showBackButton))
             }
         }
 


### PR DESCRIPTION
fixes #708