### PR TITLE
fix: [#848] Fix exportin papers with very long page indicateion to RIS format

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -77,9 +77,12 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Deprecated
 
 .Removed
+////
 
 .Fixed
+- {url-issues}848[#848] Fix exporting papers to RIS format with very large pages indication
 
+////
 .Security
 ////
 

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/logic/exporting/RisAdapter.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/logic/exporting/RisAdapter.kt
@@ -69,8 +69,8 @@ sealed class JRisAdapter(
     @Suppress("LongParameterList")
     protected abstract fun newRisRecord(
         p: Paper,
-        startPage: Int?,
-        endPage: Int?,
+        startPage: Long?,
+        endPage: Long?,
         periodical: String,
         volume: String?,
         issue: String?
@@ -110,8 +110,8 @@ sealed class JRisAdapter(
                 periodical = groups[i++],
                 volume = groups[i++],
                 issue = groups[i++].takeUnless { it.trim().isBlank() },
-                startPage = groups[i++].run { if (isNotEmpty()) toInt() else null },
-                endPage = groups[i].run { if (isNotEmpty()) toInt() else null }
+                startPage = groups[i++].run { if (isNotEmpty()) toLongOrNull() else null },
+                endPage = groups[i].run { if (isNotEmpty()) toLongOrNull() else null }
             )
         }
         return LocationComponents(location)
@@ -121,8 +121,8 @@ sealed class JRisAdapter(
         val periodical: String,
         val volume: String? = null,
         val issue: String? = null,
-        val startPage: Int? = null,
-        val endPage: Int? = null
+        val startPage: Long? = null,
+        val endPage: Long? = null
     )
 
     companion object {
@@ -152,8 +152,8 @@ class DefaultRisAdapter(
 ) : JRisAdapter(dbName, internalUrl, publicUrl) {
     override fun newRisRecord(
         p: Paper,
-        startPage: Int?,
-        endPage: Int?,
+        startPage: Long?,
+        endPage: Long?,
         periodical: String,
         volume: String?,
         issue: String?
@@ -200,8 +200,8 @@ class DistillerSrRisAdapter(
     override fun build(papers: List<Paper>) = build(papers, defaultDistillerSort)
     override fun newRisRecord(
         p: Paper,
-        startPage: Int?,
-        endPage: Int?,
+        startPage: Long?,
+        endPage: Long?,
         periodical: String,
         volume: String?,
         issue: String?
@@ -227,7 +227,7 @@ class DistillerSrRisAdapter(
             databaseName = dbName
         )
 
-    private fun getPages(sp: Int?, ep: Int?) = when {
+    private fun getPages(sp: Long?, ep: Long?) = when {
         sp == null && ep == null -> null
         ep == null -> sp.toString()
         sp == null -> ep.toString()

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/logic/export/DefaultRisAdapterTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/logic/export/DefaultRisAdapterTest.kt
@@ -2,10 +2,13 @@ package ch.difty.scipamato.core.logic.export
 
 import ch.difty.scipamato.core.entity.Paper
 import ch.difty.scipamato.core.logic.exporting.DefaultRisAdapter
+import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldContainAll
 import org.amshove.kluent.shouldNotContain
 import org.amshove.kluent.shouldNotContainAny
+import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.withMessage
 import org.junit.jupiter.api.Test
 
 @Suppress("SpellCheckingInspection")
@@ -53,7 +56,7 @@ internal class DefaultRisAdapterTest {
     }
 
     @Test
-    fun canParseSimplePaperWithOneAuthorAndSipleButNonParseableLocation() {
+    fun canParseSimplePaperWithOneAuthorAndSimpleButNonParseableLocation() {
         val expected =
             """TY  - JOUR
                   |AU  - Bond,J.
@@ -372,4 +375,48 @@ internal class DefaultRisAdapterTest {
             |""".trimMargin()
         adapter.build(listOf(p)) shouldBeEqualTo expected
     }
+
+    @Test
+    fun bug848_withPmId32733175() {
+        val paper = Paper().apply {
+            number = 10215
+            pmId = 32733175
+            doi = "10.1177/1559325820942699"
+            title = "The Association Between PM2.5 and Depression in China."
+            authors = "He G, Chen Y, Wang S, Dong Y, Ju G, Chen B."
+            publicationYear = 2020
+            location = "Dose Response. 2020; 18 (3): 1559325820942699."
+            goals = "goals"
+            originalAbstract = "original abstract"
+        }
+        val expected =
+            """TY  - JOUR
+                  |AU  - He,G.
+                  |AU  - Chen,Y.
+                  |AU  - Wang,S.
+                  |AU  - Dong,Y.
+                  |AU  - Ju,G.
+                  |AU  - Chen,B.
+                  |PY  - 2020
+                  |TI  - The Association Between PM2.5 and Depression in China.
+                  |JO  - Dose Response
+                  |SP  - 1559325820942699
+                  |VL  - 18
+                  |IS  - 3
+                  |ID  - 32733175
+                  |DO  - 10.1177/1559325820942699
+                  |M1  - 10215
+                  |M2  - goals
+                  |AB  - original abstract
+                  |DB  - scipamato
+                  |L1  - https://scipamato.ch/paper/number/10215
+                  |L2  - http://localhost:8080/32733175
+                  |ER  - 
+                  |
+              """.trimMargin()
+//        adapter.build(listOf(paper)) shouldBeEqualTo expected // BUG
+        invoking { adapter.build(listOf(paper)) } shouldThrow
+            NumberFormatException::class withMessage "For input string: \"1559325820942699\""
+    }
+
 }

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/logic/export/DefaultRisAdapterTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/logic/export/DefaultRisAdapterTest.kt
@@ -2,13 +2,10 @@ package ch.difty.scipamato.core.logic.export
 
 import ch.difty.scipamato.core.entity.Paper
 import ch.difty.scipamato.core.logic.exporting.DefaultRisAdapter
-import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldContainAll
 import org.amshove.kluent.shouldNotContain
 import org.amshove.kluent.shouldNotContainAny
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
 import org.junit.jupiter.api.Test
 
 @Suppress("SpellCheckingInspection")
@@ -414,9 +411,7 @@ internal class DefaultRisAdapterTest {
                   |ER  - 
                   |
               """.trimMargin()
-//        adapter.build(listOf(paper)) shouldBeEqualTo expected // BUG
-        invoking { adapter.build(listOf(paper)) } shouldThrow
-            NumberFormatException::class withMessage "For input string: \"1559325820942699\""
+        adapter.build(listOf(paper)) shouldBeEqualTo expected
     }
 
 }


### PR DESCRIPTION
Fixes #848

Allows exporting papers with large pages indicateion to RIS, e.g. https://pubmed.ncbi.nlm.nih.gov/32733175/ with location "Dose Response. 2020; 18 (3): 1559325820942699."

The Adapter now tries to parse the page (any of start page and end page) using longs instead of ints. If it can't be parsed to the respecive numeric values, we fall back to `null`.