### PR TITLE
feat: [#911] Add exclamation mark to name of search orders with exclusions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -71,9 +71,10 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 
 .Added
 
-////
 .Changed
+- {url-issues}911[#911] Search Order name to indicate excluded papers with an exclamation mark
 
+////
 .Deprecated
 
 .Removed

--- a/core/core-entity/src/main/java/ch/difty/scipamato/core/entity/search/SearchOrder.java
+++ b/core/core-entity/src/main/java/ch/difty/scipamato/core/entity/search/SearchOrder.java
@@ -171,6 +171,10 @@ public class SearchOrder extends IdScipamatoEntity<Long> implements PaperSlimFil
             sb.delete(DISPL_VALUE_CUTOFF, sb.length());
             sb.append(DISPL_VALUE_ELLIPSIS);
         }
+
+        if (!excludedPaperIds.isEmpty())
+            sb.append(" !");
+
         return sb;
     }
 

--- a/core/core-entity/src/test/kotlin/ch/difty/scipamato/core/entity/search/SearchOrderTest.kt
+++ b/core/core-entity/src/test/kotlin/ch/difty/scipamato/core/entity/search/SearchOrderTest.kt
@@ -217,6 +217,17 @@ internal class SearchOrderTest {
     }
 
     @Test
+    fun testingFullDisplayValue_withoutNameButWithSingleConditionAndExclusions_returnsIt() {
+        val so1 = SearchOrder(10L, null, 1, false, null, listOf(2L))
+        so1.add(object : SearchCondition() {
+            private val serialVersionUID: Long = 1L
+            override fun getDisplayValue(): String = "f1DisplayValue"
+        })
+
+        so1.displayValue shouldBeEqualTo "f1DisplayValue ! (10)"
+    }
+
+    @Test
     fun testingFullDisplayValue_withSingleCondition_returnsIt() {
         so.add(object : SearchCondition() {
             private val serialVersionUID: Long = 1L
@@ -278,6 +289,12 @@ internal class SearchOrderTest {
         })
         so.displayValue shouldBeEqualTo "soName: c1DisplayValue; OR c2DisplayValue; " +
             "OR c3DisplayValue; OR c4DisplayValue; OR c5DisplayValu... (10)"
+
+        so.addExclusionOfPaperWithId(1L)
+
+        so.displayValue shouldBeEqualTo "soName: c1DisplayValue; OR c2DisplayValue; " +
+            "OR c3DisplayValue; OR c4DisplayValue; OR c5DisplayValu... ! (10)"
+
     }
 
     @Test

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/entry/EditablePaperPanel.java
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/paper/entry/EditablePaperPanel.java
@@ -610,7 +610,7 @@ public abstract class EditablePaperPanel extends PaperPanel<Paper> {
                     setIconType(FontAwesome6IconType.circle_check_s);
                     add(new AttributeModifier(TITLE_ATTR, new StringResourceModel("button.exclude.title.reinclude", this, null).getString()));
                 } else {
-                    setIconType(FontAwesome6IconType.circle_minus_s);
+                    setIconType(FontAwesome6IconType.ban_s);
                     add(new AttributeModifier(TITLE_ATTR, new StringResourceModel("button.exclude.title.exclude", this, null).getString()));
                 }
             }

--- a/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/entry/EditablePaperPanelInEditModeTest.kt
+++ b/core/core-web/src/test/kotlin/ch/difty/scipamato/core/web/paper/entry/EditablePaperPanelInEditModeTest.kt
@@ -642,7 +642,7 @@ internal class EditablePaperPanelInEditModeTest : EditablePaperPanelTest() {
         assertExcluded(
             false,
             "Exclude paper from current search",
-            "fa-circle-minus"
+            "fa-ban"
         )
     }
 


### PR DESCRIPTION
Amend the search order display name to include an exclamation mark if the search order has defined paper exclusions.

- [x] Adjust display name
- [x] Use same icon for button to exclude paper from search between result panel and paper panel
- [x] Wiki documentation