### PR TITLE
fix: restore jasperreport compilation when running application with java -jar

### DIFF
--- a/core/core-web/build.gradle.kts
+++ b/core/core-web/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
         exclude("commons-collections", "commons-collections")
         exclude("commons-logging", "commons-logging")
     }
+    implementation(libs.jasperreports.jdt)
     implementation(libs.jasperreports.fonts)
     implementation(libs.jasperreports.pdf)
     implementation(libs.univocity)

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/resources/jasper/JasperReportResourceReference.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/resources/jasper/JasperReportResourceReference.kt
@@ -9,8 +9,6 @@ import org.apache.wicket.util.resource.IResourceStream
 import org.apache.wicket.util.resource.ResourceStreamNotFoundException
 import java.io.InputStream
 import java.io.Serializable
-import javax.tools.ToolProvider
-import net.sf.jasperreports.engine.DefaultJasperReportsContext
 
 private val log = logger()
 
@@ -49,8 +47,6 @@ abstract class JasperReportResourceReference(
 
     @Throws(JRException::class)
     open fun compileReport() {
-        applyDiagnosticLogging()
-
         report = JasperCompileManager.compileReport(inputStream)
         log.info { "Successfully compiled JasperReport $name..." }
     }
@@ -74,27 +70,6 @@ abstract class JasperReportResourceReference(
 
     open val resourceStreamFromResource: IResourceStream?
         get() = resource.resourceStream
-
-    private fun applyDiagnosticLogging() {
-        val cl = Thread.currentThread().contextClassLoader
-        log.info { "Context CL = $cl" }
-        log.info {
-            cl.getResource(
-                "net/sf/jasperreports/engine/JasperReport.class"
-            )
-        }
-        log.info {
-            JasperCompileManager::class.java.protectionDomain.codeSource.location
-        }
-        log.info {
-            "SystemJavaCompiler = ${ToolProvider.getSystemJavaCompiler()}"
-        }
-        log.info {
-            "JasperCompileManager CL = ${JasperCompileManager::class.java.classLoader}"
-        }
-        Thread.currentThread().contextClassLoader =
-            JasperCompileManager::class.java.classLoader
-    }
 
     companion object {
         private const val serialVersionUID = 1L

--- a/core/core-web/src/main/java/ch/difty/scipamato/core/web/resources/jasper/JasperReportResourceReference.kt
+++ b/core/core-web/src/main/java/ch/difty/scipamato/core/web/resources/jasper/JasperReportResourceReference.kt
@@ -9,6 +9,8 @@ import org.apache.wicket.util.resource.IResourceStream
 import org.apache.wicket.util.resource.ResourceStreamNotFoundException
 import java.io.InputStream
 import java.io.Serializable
+import javax.tools.ToolProvider
+import net.sf.jasperreports.engine.DefaultJasperReportsContext
 
 private val log = logger()
 
@@ -47,6 +49,8 @@ abstract class JasperReportResourceReference(
 
     @Throws(JRException::class)
     open fun compileReport() {
+        applyDiagnosticLogging()
+
         report = JasperCompileManager.compileReport(inputStream)
         log.info { "Successfully compiled JasperReport $name..." }
     }
@@ -70,6 +74,27 @@ abstract class JasperReportResourceReference(
 
     open val resourceStreamFromResource: IResourceStream?
         get() = resource.resourceStream
+
+    private fun applyDiagnosticLogging() {
+        val cl = Thread.currentThread().contextClassLoader
+        log.info { "Context CL = $cl" }
+        log.info {
+            cl.getResource(
+                "net/sf/jasperreports/engine/JasperReport.class"
+            )
+        }
+        log.info {
+            JasperCompileManager::class.java.protectionDomain.codeSource.location
+        }
+        log.info {
+            "SystemJavaCompiler = ${ToolProvider.getSystemJavaCompiler()}"
+        }
+        log.info {
+            "JasperCompileManager CL = ${JasperCompileManager::class.java.classLoader}"
+        }
+        Thread.currentThread().contextClassLoader =
+            JasperCompileManager::class.java.classLoader
+    }
 
     companion object {
         private const val serialVersionUID = 1L

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql" }
 fontAwesome = { module = "org.webjars:font-awesome" }
 hibernate-validator = { module = "org.hibernate.validator:hibernate-validator" }
 jasperreports = { module = "net.sf.jasperreports:jasperreports", version.ref = "jasperreports" }
+jasperreports-jdt = { module = "net.sf.jasperreports:jasperreports-jdt", version.ref = "jasperreports" }
 jasperreports-fonts = { module = "net.sf.jasperreports:jasperreports-fonts", version.ref = "jasperreports" }
 jasperreports-pdf = { module = "net.sf.jasperreports:jasperreports-pdf", version.ref = "jasperreports" }
 jakarta-el-api = { module = "jakarta.el:jakarta.el-api", version.ref = "jakartaElApi" }


### PR DESCRIPTION
When starting the application from sources, all was working file ("works on my machine"). However, the deployed version runs using systemd and `java -jar`.

With the update to jasperreports-7, the jasper report compile process was unable to find jasperreports when trying to compile the java classes (successfully) created from the jrxml files.

Adding an explicit dependency on `jasperreports-jdt` resolved the issue.