### PR TITLE
fix: [#1230] disable tagged PDF export to resolve JasperReports 7 incompatibility

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -67,7 +67,7 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 [[unreleased]]
 == [unreleased]
 
-{url-cl}2.3.1++...++main[Full Changelog]
+{url-cl}2.3.2++...++main[Full Changelog]
 
 .Added
 
@@ -84,6 +84,15 @@ NOTE: References to user stories are in the form Iteration/Story-Number.
 .Security
 
 ////
+
+[[v2.3.2]]
+== {url-tree}2.3.2[2.3.2] -- 2026-08-21
+
+{url-cl}2.3.1++...++2.3.2[Full Changelog]
+
+.Fixed
+- {url-issues}1230[#1230] Bug: PDF creation from single paper trhows an error
+
 
 [[v2.3.1]]
 == {url-tree}2.3.1[2.3.1] -- 2026-08-20

--- a/core/core-web/src/main/resources/jasperreports.properties
+++ b/core/core-web/src/main/resources/jasperreports.properties
@@ -1,0 +1,2 @@
+net.sf.jasperreports.export.pdf.tagger.factory=net.sf.jasperreports.pdf.common.SilentPdfTaggerFactory
+


### PR DESCRIPTION
Fixes #1230

JasperReports 7.0.8 removed tagged PDF support from the Community Edition. Any report with tagging/accessibility properties enabled now throws:

  net.sf.jasperreports.engine.JRRuntimeException:
  Tagged PDF export is not supported.

Fix by adding a jasperreports.properties file that redirects the tagger factory to the built-in no-op implementation:

  net.sf.jasperreports.export.pdf.tagger.factory=
    net.sf.jasperreports.pdf.common.SilentPdfTaggerFactory

This silently skips PDF tagging (accessibility metadata) instead of throwing, restoring PDF export for all affected reports. Tagged PDF would require the JasperReports Professional (commercial) edition.